### PR TITLE
List and const blocks, and read persistence shorthand

### DIFF
--- a/KSP.tmLanguage
+++ b/KSP.tmLanguage
@@ -221,7 +221,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(declare|define) +(global |local |pers )?(ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_knob|ui_table|call|step|ui_text_edit|ui_level_meter|ui_file_selector) *([a-zA-Z0-9_.]+) *\(</string>
+			<string>(declare|define) +(global |local |pers |read )?(ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_knob|ui_table|call|step|ui_text_edit|ui_level_meter|ui_file_selector) *([a-zA-Z0-9_.]+) *\(</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -261,7 +261,7 @@
 			<key>comment</key>
 			<string>Other keywords</string>
 			<key>match</key>
-			<string>\b(define|pers|list|function|taskfunc|macro|declare|const|polyphonic|end|local|global|family|import|as|property|override|declare|ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_knob|ui_table|call|step|ui_text_edit|ui_level_meter|ui_file_selector)\b</string>
+			<string>\b(define|pers|read|list|function|taskfunc|macro|declare|const|polyphonic|end|local|global|family|import|as|property|override|declare|ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_knob|ui_table|call|step|ui_text_edit|ui_level_meter|ui_file_selector)\b</string>
 			<key>name</key>
 			<string>keyword.other.source.ksp</string>
 		</dict>

--- a/ksp_compiler3/preprocessor_plugins.py
+++ b/ksp_compiler3/preprocessor_plugins.py
@@ -619,7 +619,6 @@ def variable_persistence_shorthand(lines):
 	line_numbers = []
 	variable_names = []
 
-
 	for i in range(len(lines)):
 		line = lines[i].command.strip()
 		if re.search(r"^\s*declare\s+pers\s+", line):
@@ -672,13 +671,21 @@ def handle_iterate_macro(lines):
 	macro_name = []
 	line_numbers = []
 	downto = []
+	is_single_line = []
 
 	for index in range(len(lines)):
 		line = lines[index].command
-		if re.search(r"^\s*iterate_macro\(", line):
-			name = line[line.find("(") + 1 : line.find(")")]
-			params = line[line.find(")") + 1:]
+		if re.search(r"^\s*iterate_macro\s*\(", line):
+			m = re.search(r"^\s*iterate_macro\s*\((.+)\)\s*(:=.+)", line)
+			name = m.group(1)
+			params = m.group(2)
 			try:
+
+				find_n = False
+				if "#n#" in name:
+					find_n = True
+				is_single_line.append(find_n)
+
 				if "downto" in params:
 					to_stmt = "downto"
 					downto.append(True)
@@ -726,6 +733,8 @@ def handle_iterate_macro(lines):
 
 			for ii in range(int(min_val[i]), int(max_val[i]) + offset, step):
 				current_text = macro_name[i] + "(" + str(ii) + ")"
+				if is_single_line[i]:
+					current_text = macro_name[i].replace("#n#", str(ii))
 				new_lines.append(lines[line_numbers[i]].copy(current_text))
 
 			if i + 1 < len(line_numbers):


### PR DESCRIPTION
Code in the preprocessor_plugins file has been considerably tidied up.

Bug fixes:
- Bug with using tabs in define statements.
- Similarly named lists now work.

New syntax:
- New list blocks. Instead of using a whole load of list_add() commands, you can declare a list and assign it a set of values in a code block. list_add() still works as normal. There is also a constant variable for the list size generated.
	```
	list !menuItemText
		"Oscillator"
		"Filter"  
		"LFO"
	end list
	message(menuItemText[0])
	message(menuItemText.SIZE)

	list myList
		99
		24
		get_ui_id(volSlider)
		get_ui_id(tuneSlider)
		get_ui_id(panSlider)
	end list
	```

- New constant integer blocks. You can create a set of constant integers in a block. The value of the constants can optionally be automatic, by default the first is 0 and each one after is the previous + 1. There is also an integer array generated, though as usual if you do not use it, the compiler will omit it when 'Optimise compiled code' is on.
	```
	const colours
        WHITE := 9FFFFFFh
        BLACK := 9000000h
        RED   := 9FF0000h
        GREEN := 900FF00h
        BLUE  := 90000FFh
	end const
	message(colours.SIZE)
	message(colours.BLACK)
	message(colours[0])

	const types
		SEQUENCER // Auto generated to equal 0
		LFO       // Auto generated to equal 1
		GRID      // Auto generated to equal 2
	end const
	declare read ui_slider slider(0, types.SIZE - 1)
	if slider = types.SEQUENCER
		message(slider)
	end if
	```

- New shorthand for read_persistent_var(). For any variable you can use the keyword 'read' to both make the variable persistent and also read its persistent value. The 'pers' keyword only makes it persistent.
	```
	declare read variable
	declare read ui_slider sliders[20] (0, 100)
	```
- New iterate_macro functionality. There is a short way of iterating a one line macro. Simply put the line you wish to repeat in the brackets of the iterate_macro() command, and use the token #n# to show the places that you want numbers to be substituted. At least 1 #n# token must be found to use this functionality.
	```
	define NUM_MENUS := 20
	declare ui_menu menus[NUM_MENUS]
	iterate_macro(add_menu_item(menus#n#, "Item", 0)) := 0 to NUM_MENUS - 1
	```

- New define functionality. You can use define as a literal text substitution macro. To do this, sandwich the value with # symbols. The text inside the # is replaced at the location you use the define, so be careful with this.