### PR TITLE
Multidimensional UI arrays

### DIFF
--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -79,7 +79,7 @@ contexts:
       captures:
         1: keyword.other.source.ksp
         2: meta.function-call.source.ksp
-    - match: '(declare|define) +(literals| global |local |pers |read )?(ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_knob|ui_table|call|step|ui_text_edit|ui_level_meter|ui_file_selector) *([a-zA-Z0-9_.]+) *\('
+    - match: '(declare|define) +(literals |global |local |pers |read )?(ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_knob|ui_table|call|step|ui_text_edit|ui_level_meter|ui_file_selector) *([a-zA-Z0-9_.]+) *\('
       comment: Declaration of UI variable
       captures:
         1: keyword.other.source.ksp

--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -79,7 +79,7 @@ contexts:
       captures:
         1: keyword.other.source.ksp
         2: meta.function-call.source.ksp
-    - match: '(declare|define( +literals)?) +(global |local |pers |read )?(ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_knob|ui_table|call|step|ui_text_edit|ui_level_meter|ui_file_selector) *([a-zA-Z0-9_.]+) *\('
+    - match: '(declare|define) +(literals| global |local |pers |read )?(ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_knob|ui_table|call|step|ui_text_edit|ui_level_meter|ui_file_selector) *([a-zA-Z0-9_.]+) *\('
       comment: Declaration of UI variable
       captures:
         1: keyword.other.source.ksp


### PR DESCRIPTION
Create multidimensional UI arrays. This works in the same way that normal multidimensional arrays work. If you want to access the single dimension version you prefix the name with an underscore. Because UI elements also have a variable name, these will also have the underscore. You must use define constants or literals for the array dimensions. There is no automatically generated .SIZE_D1 constants like in the regular multidimensional arrays.

```
on init
	define NUM_LAYERS := 4
	define NUM_CONTROLS := 4

	// Create all of the UI in one command. The total number of controls created 
	// is simply equal to NUM_LAYERS * NUM_CONTROLS.
	declare pers ui_slider sliders[NUM_LAYERS, NUM_CONTROLS] (0, 100)

	declare i
	declare j
	for i := 0 to NUM_LAYERS - 1
		for j := 0 to NUM_CONTROLS - 1
			set_bounds(sliders[i, j], 10 + 40 * i, 10)
		end for
	end for
end on

function hideAllSliders()
	// Here is an example of how you might want to use the single dimension version
	// to effect all the sliders at once.
	for i := 0 to num_elements(_sliders)
		_sliders[i] -> hide := HIDE_WHOLE_CONTROL
	end for
end function

macro sliderCallbacks(#n#)
	on ui_control(_sliders#n#) // The single dimension version has an underscore.
		message(_sliders#n#)
	end on
end macro
iterate_macro(sliderCallbacks) := 0 to NUM_LAYERS * NUM_CONTROLS - 1 
```

