### PR TITLE
Macros can accept args with dots in them

### DIFF
--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -64,7 +64,7 @@ contexts:
           pop: true
         - match: "out |in "
           scope: keyword.other.source.ksp
-        - match: "[a-zA-Z0-9_#]+"
+        - match: "[a-zA-Z0-9_#.]+"
           scope: variable.parameter.function.source.ksp
         - include: main
     - match: '^\s*(family +)([a-zA-Z_.0-9]+)'

--- a/ksp_compiler3/ksp_compiler.py
+++ b/ksp_compiler3/ksp_compiler.py
@@ -224,7 +224,7 @@ class Macro:
 
 	def get_macro_name_and_parameters(self):
 		""" returns the function name, parameter list, and result variable (or None) as a tuple """
-		param = white_space + r'([$%@!]?\w+|#\w+#)' + white_space
+		param = white_space + r'([$%@!]?[\w\.]+|#[\w\.]+#)' + white_space
 		params = r'%s(,%s)*' % (param, param)
 		m = re.match(r'^\s*macro\s+(?P<name>[a-zA-Z0-9_]+(\.[a-zA-Z_0-9.]+)*)\s*(?P<params>\(%s\))?' % params, self.lines[0].command)
 		if not m:

--- a/ksp_compiler3/preprocessor_plugins.py
+++ b/ksp_compiler3/preprocessor_plugins.py
@@ -64,9 +64,9 @@ def pre_macro_functions(lines):
 def post_macro_functions(lines):
 	""" This function is called after the regular macros have been expanded. lines is a 
 	collections.deque of Line objects - see ksp_compiler.py."""
-	handleStructs(lines)
 	handleIncrementer(lines)
 	handleConstBlock(lines)
+	handleStructs(lines)
 	handleUIArrays(lines)
 	handleSameLineDeclaration(lines)
 	handleMultidimensionalArrays(lines)


### PR DESCRIPTION
Sorry, typical that I find a couple of tiny bugs just after an update... This is nothing particularly important though.

Bug fix
- Macros can now accept arguments with dots in them, while before it would reject them.