### PR TITLE
Fixed syntax coloring of double-quote strings

### DIFF
--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -99,7 +99,7 @@ contexts:
     - match: (?!#)\b(struct|define|literals|on|pers|instpers|read|list +|function|taskfunc|macro|declare|const|polyphonic|end|local|global|family|import|as|property|override|declare|ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_knob|ui_table|ui_xy|call|step|ui_text_edit|ui_level_meter|ui_file_selector)\b(?!#)
       comment: Other keywords
       scope: keyword.other.source.ksp
-    - match: '".*?"'
+    - match: '"(?:[^"\\]|\\.)*"'
       comment: Double-quoted string
       scope: string.quoted.double.source.ksp
     - match: "'.*?'"


### PR DESCRIPTION
Now double-quote strings containing an escaped double-quote string is colored properly.