### PR TITLE
Changed how syntax file is referenced in ksp_plugin.py

### DIFF
--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -449,7 +449,7 @@ class KspFixLineEndings(sublime_plugin.EventListener):
             return False
 
     def set_ksp_syntax(self, view):
-        view.set_syntax_file("Packages/KSP (Kontakt Script Processor)/KSP.sublime-syntax")
+        view.set_syntax_file("KSP.sublime-syntax")
 
     def on_load(self, view):
         if self.is_probably_ksp_file(view):


### PR DESCRIPTION
There was no need to add folders to the KSP.sublime-syntax file, it seems that view.set_syntax_file() works relative to the plugin's folder itself.

This should work with both uncompressed and compressed sKSP the same.