### PR TITLE
Fixed syntax coloring of "out" keyword

### DIFF
--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -68,7 +68,7 @@ contexts:
         - meta_scope: function.ksp
         - match: \)|$
           pop: true
-        - match: "out|in "
+        - match: "out |in "
           scope: keyword.other.source.ksp
         - match: "[a-zA-Z0-9_#.]+"
           scope: variable.parameter.function.source.ksp


### PR DESCRIPTION
Previously it would color "out" even if it was only a part of argument (i.e. "out_min"), now it requires a whitespace after "out" to color properly. Just like "in" keyword, in fact.