### PR TITLE
Updated keycoloring for "end" keywords

### DIFF
--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -96,7 +96,10 @@ contexts:
         - match: \)|$
           pop: true
         - include: main
-    - match: (?!#)\b(struct|define|literals|on|pers|instpers|read|list +|function|taskfunc|macro|declare|const|polyphonic|end|local|global|family|import|as|property|override|declare|ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_wavetable|ui_knob|ui_table|ui_xy|call|step|ui_text_edit|ui_level_meter|ui_file_selector)\b(?!#)
+    - match: '^(\s*(end)?\s*)(struct|on|function|taskfunc|macro|const|family|if|for|while|select|property)'
+      comment: End keywords
+      scope: keyword.other.source.ksp
+    - match: (?!#)\b(on|pers|instpers|read|list|polyphonic|local|global|import|as|override|declare|ui_label|ui_button|ui_switch|ui_slider|ui_menu|ui_value_edit|ui_waveform|ui_wavetable|ui_knob|ui_table|ui_xy|call|step|ui_text_edit|ui_level_meter|ui_file_selector)\b(?!#)
       comment: Other keywords
       scope: keyword.other.source.ksp
     - match: '"(?:[^"\\]|\\.)*"'


### PR DESCRIPTION
Preivously, any keywords that had an "end" variant (end on, end macro, end function, etc.) would be colored as keywords even when used in function/macro arguments or as a variable.

This change attempts to fix that issue by adding a new match query specifically for those keywords.