### PR TITLE
Recognize XY pad as UI control callback

### DIFF
--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -25,7 +25,7 @@ contexts:
     - match: "[,.()\\[\\]]"
       comment: Punctuation and brackets
       scope: punctuation
-    - match: '(on\s+ui_control)(\s*\(([a-zA-Z0-9$%@_.]+)\))?'
+    - match: '(on\s+ui_control)(\s*\(([a-zA-Z0-9$%@?_.]+)\))?'
       comment: UI callback
       captures:
         0: entity.name.callback.source.ksp


### PR DESCRIPTION
Previously if we had UICBs for XY pad controls, they wouldn't show up in Sublime's symbol list (where other functions and callbacks are listed). Now they do.