### PR TITLE
Fixed the Ancient String Comma Bug

### DIFF
--- a/ksp_compiler3/ksp_compiler.py
+++ b/ksp_compiler3/ksp_compiler.py
@@ -118,11 +118,12 @@ def split_args(arg_string, line):
     single_quote_on = False
     double_quote_on = False
 
+    print(arg_string)
     for idx, ch in enumerate(arg_string + ','):    # extra ',' to include the last argument
         # square brackets are also checked as there may be commas in them (for properties/2D arrays)
         if ch is '\'':
             single_quote_on = not single_quote_on
-        elif ch is '\"' and idx > 0 and arg_string[idx - 1] is not '\\':
+        elif ch is '\"' and (idx == 0 or arg_string[idx - 1] is not '\\'):
             double_quote_on = not double_quote_on
         elif ch in ['(', '[']:
             unmatched_left_paren += 1

--- a/ksp_compiler3/ksp_compiler.py
+++ b/ksp_compiler3/ksp_compiler.py
@@ -115,13 +115,20 @@ def split_args(arg_string, line):
     args = []
     cur_arg = ''
     unmatched_left_paren = 0
-    for ch in arg_string + ',':    # extra ',' to include the last argument
+    single_quote_on = False
+    double_quote_on = False
+
+    for idx, ch in enumerate(arg_string + ','):    # extra ',' to include the last argument
         # square brackets are also checked as there may be commas in them (for properties/2D arrays)
-        if ch == '(' or ch == '[':
+        if ch is '\'':
+            single_quote_on = not single_quote_on
+        elif ch is '\"' and idx > 0 and arg_string[idx - 1] is not '\\':
+            double_quote_on = not double_quote_on
+        elif ch in ['(', '[']:
             unmatched_left_paren += 1
-        elif ch == ')' or ch == ']':
+        elif ch in [')', ']']:
             unmatched_left_paren -= 1
-        if ch == ',' and unmatched_left_paren == 0:
+        if ch == ',' and unmatched_left_paren == 0 and not single_quote_on and not double_quote_on:
             cur_arg = cur_arg.strip()
             if not cur_arg:
                 raise ParseException(line, 'Syntax error - empty argument in function call: %s' % arg_string)

--- a/ksp_compiler3/preprocessor_plugins.py
+++ b/ksp_compiler3/preprocessor_plugins.py
@@ -981,7 +981,7 @@ def handleOpenSizeArrays(lines):
 		line = lines[lineIdx].command.strip()
 		m = re.search(openArrayRe, line)
 		if m:
-			stringList = re.split(commasNotInBrackets, line[line.find("(") + 1 : len(line) - 1])
+			stringList = ksp_compiler.split_args(line[line.find("(") + 1 : len(line) - 1], line)
 			numElements = len(stringList)
 			name = m.group("name")
 			newLines.append(lines[lineIdx].copy(line[: line.find("[") + 1] + str(numElements) + line[line.find("[") + 1 :]))


### PR DESCRIPTION
After some prompting from EvilDragon, I took a look into the compiler to see why string arguments with commas in various situations were breaking. It was obvious that the commas were being treated as argument separators, and it turned out that there was really no logic in place to handle when commas were encased in quotes. Supports single and double quote strings with commas, and you can even escape quotes as well.