### PR TITLE
Fixed incorrect behavior of "Raise error on empty if/case" menu entry

### DIFF
--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -345,12 +345,12 @@ class KspGlobalSettingToggleCommand(sublime_plugin.ApplicationCommand):
     def is_enabled(self, setting, default):
         extra_checks = bool(sublime.load_settings("KSP.sublime-settings").get("ksp_extra_checks", default))
         optim_code = bool(sublime.load_settings("KSP.sublime-settings").get("ksp_optimize_code", default))
-        signal_empty = bool(sublime.load_settings("KSP.sublime-settings").get("ksp_signal_empty_ifcase", default))
+        signal_empty = not (extra_checks and optim_code)
 
         if setting == "ksp_optimize_code":
             return extra_checks
         elif setting == "ksp_signal_empty_ifcase":
-            return signal_empty and not (extra_checks and optim_code)
+            return signal_empty
         else:
             return True
 


### PR DESCRIPTION
It was always grayed out even if Extra syntax checks/Optimize compiled core were both disabled.