### PR TITLE
Don't expand empty strings from an inline string array declaration

### DIFF
--- a/ksp_compiler3/preprocessor_plugins.py
+++ b/ksp_compiler3/preprocessor_plugins.py
@@ -1021,7 +1021,12 @@ def handleStringArrayInitialisation(lines):
 					newLines.append(lines[i].copy(line[: line.find(":")]))
 					if len(stringList) != 1:
 						for ii in range(len(stringList)):
-							newLines.append(lines[i].copy("%s[%s] := %s" % (name, str(ii), stringList[ii])))
+							# get our actual string from placeholders array
+							strVal = ksp_compiler.placeholders[int(stringList[ii][1:-1])]
+
+							# if it's an empty string, don't add it to new lines
+							if strVal != '\"\"':
+								newLines.append(lines[i].copy("%s[%s] := %s" % (name, str(ii), stringList[ii])))
 					else:
 						newLines.append(lines[i].copy("for string_it := 0 to %s - 1" % m.group("arraysize")))
 						newLines.append(lines[i].copy("%s[string_it] := %s" % (name, "".join(stringList))))


### PR DESCRIPTION
Up until now, SublimeKSP just expanded any and all strings from an inline string array declaration, which could result in a lot of unnecessary empty string assignments with larger (especially multidimensional) string array inline declarations.

Be smarter about it by doing a string value check, if the placeholder points to `""` then just don't append that string to `newLines`, which cleans up the compiled code.