### PR TITLE
Remove "Insert Comments When Expanding Functions" option

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -86,13 +86,6 @@
 					},
 					{
 						"command": "ksp_global_setting_toggle",
-						"args": {"setting": "ksp_comment_inline_functions", "default": false},
-						"caption": "Insert Comments When Expanding Functions",
-						"mnemonic": "F",
-						"id": "comment_inline_functions"
-					},
-					{
-						"command": "ksp_global_setting_toggle",
 						"args": {"setting": "ksp_signal_empty_ifcase", "default": true},
 						"caption": "Raise Error on Empty 'if' or 'case' Statements",
 						"mnemonic": "R",

--- a/ksp_compiler3/ksp_compiler.py
+++ b/ksp_compiler3/ksp_compiler.py
@@ -1598,12 +1598,11 @@ def strip_import_nckp_function_from_source(lines):
             line_obj.command = re.sub(r'[^\r\n]', '', ls_line)
 
 class KSPCompiler(object):
-    def __init__(self, source, basedir, compact=True, compactVars=False, comments_on_expansion=True, read_file_func=default_read_file_func, extra_syntax_checks=False, optimize=False, check_empty_compound_statements=False, add_compiled_date_comment=False):
+    def __init__(self, source, basedir, compact=True, compactVars=False, read_file_func=default_read_file_func, extra_syntax_checks=False, optimize=False, check_empty_compound_statements=False, add_compiled_date_comment=False):
         self.source = source
         self.basedir = basedir
         self.compact = compact
         self.compactVars = compactVars
-        self.comments_on_expansion = comments_on_expansion
         self.read_file_func = read_file_func
         self.optimize = optimize
         self.check_empty_compound_statements = check_empty_compound_statements
@@ -2017,7 +2016,6 @@ if __name__ == "__main__":
         basedir,
         compact=args.compact,
         compactVars=args.compact_variables,
-        comments_on_expansion=False,
         read_file_func=read_file_func,
         extra_syntax_checks=args.extra_syntax_checks,
         optimize=args.optimize,

--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -161,7 +161,6 @@ class CompileKspThread(threading.Thread):
         compactVars = settings.get('ksp_compact_variables', False)
         check = settings.get('ksp_extra_checks', True)
         optimize = settings.get('ksp_optimize_code', False)
-        comments_on_expansion = settings.get('ksp_comment_inline_functions', False)
         check_empty_compound_statements = settings.get('ksp_signal_empty_ifcase', True)
         add_compiled_date_comment = settings.get('ksp_add_compiled_date', True)
         should_play_sound = settings.get('ksp_play_sound', False)
@@ -175,7 +174,7 @@ class CompileKspThread(threading.Thread):
         try:
             sublime.status_message('Compiling...')
 
-            self.compiler = ksp_compiler.KSPCompiler(code, self.base_path, compact, compactVars, comments_on_expansion,
+            self.compiler = ksp_compiler.KSPCompiler(code, self.base_path, compact, compactVars,
                                                      read_file_func=self.read_file_function,
                                                      extra_syntax_checks=check,
                                                      optimize=optimize and check,


### PR DESCRIPTION
It never really worked, apparently.