### PR TITLE
Fix watch_array_idx() not taking string/real arrays as argument

### DIFF
--- a/ksp_compiler3/ksp_builtins_data.py
+++ b/ksp_compiler3/ksp_builtins_data.py
@@ -1292,7 +1292,7 @@ unload_slot(<instrument-slot-idx>)
 wait(<wait-time>)
 wait_async(<event-id>):integer
 watch_var(<variable>)
-watch_array_idx(<array-variable>, <index>)
+watch_array_idx(<any-array-variable>, <index>)
 wait_ticks(<wait-time>)
 will_never_terminate(<event-id>)
 zone_slice_idx_loop_end(<zone-id>, <loop-idx>):integer

--- a/ksp_compiler3/ksp_compiler.py
+++ b/ksp_compiler3/ksp_compiler.py
@@ -1188,7 +1188,7 @@ class ASTModifierFunctionExpander(ASTModifierBase):
         if node.using_call_keyword:
             # verify that there are no parameters (unless it's a taskfunc function call)
             if not func.is_taskfunc and node.parameters:
-                raise ksp_ast.ParseException(node, "Parameters for function invokations using 'call' not supported by Kontakt")
+                raise ksp_ast.ParseException(node, "Parameters for function invocations using 'call' not supported by Kontakt")
             # verify that 'call' is not used within some expression (eg. as in the incorrect "x := call myfunc")
             if not node.is_procedure and not func.is_taskfunc:
                 raise ksp_ast.ParseException(node, 'Using "call" inside an expression is not allowed for non-taskfunc functions. "call" needs to be the first word of the line.')
@@ -1236,7 +1236,7 @@ class ASTModifierFunctionExpander(ASTModifierBase):
         return (prologue, epilogue)
 
     def modifyFunctionCall(self, node, parent_toplevel=None, function_stack=None, assign_stmt_lhs=None):
-        ''' For invokations of user-defined functions check that the function is defined and that the number of parameters match.
+        ''' For invocations of user-defined functions check that the function is defined and that the number of parameters match.
             Unless "call" is used inline the function '''
 
         function_name = node.function_name.identifier  # shorter name alias

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -206,7 +206,7 @@ def assert_type(node, type):
         raise Exception()
     node_type = node.type
     if node_type != type and not (node_type in ('integer', 'real') and type == 'numeric'):
-        raise ParseException(node, 'Expected expression of %s type, got %s.' % (type, node_type))
+        raise ParseException(node, 'Expected expression of %s type, got %s type instead.' % (type, node_type))
 
 def highest_precision(type1, type2):
     if type1 == 'real' or type2 == 'real':
@@ -239,14 +239,17 @@ class ASTVisitorDetermineExpressionTypes(ASTVisitor):
                         # special case: the abs function returns an integer or real
                         # depending on what param type it's given
                         node.type = passed_param.type
-                    elif 'array-or-string-array-variable' in param_descriptor:
+                    elif 'any-array-variable' in param_descriptor:
                         pass
+                    elif 'array-or-string-array-variable' in param_descriptor:
+                        if not passed_param.type in ('array-variable', 'string-array'):
+                            assert_type(passed_param, 'integer or string array')
                     elif 'string-array' in param_descriptor:
-                        assert_type(passed_param, 'array of string')
+                        assert_type(passed_param, 'string array')
                     elif 'array-variable' in param_descriptor:
-                        assert_type(passed_param, 'array of integer')
+                        assert_type(passed_param, 'integer array')
                     elif 'real-variable' in param_descriptor:
-                        assert_type(passed_param, 'array of real')
+                        assert_type(passed_param, 'real array')
                     elif 'key-id' in param_descriptor:
                         if not isinstance(passed_param, VarRef):
                             raise ParseException(node, 'Expected key-id.')
@@ -310,15 +313,15 @@ class ASTVisitorDetermineExpressionTypes(ASTVisitor):
         expr.type = 'string'
 
     def visitRawArrayInitializer(self, parent, expr, *args):
-        expr.type = 'array of integer'
+        expr.type = 'integer array'
 
     def visitID(self, parent, expr, *args):
         if expr.prefix:
             expr.type = {'$': 'integer',
-                         '%': 'array of integer',
+                         '%': 'integer array',
                          '@': 'string',
-                         '!': 'array of string',
-                         '?': 'array of real',
+                         '!': 'string array',
+                         '?': 'real array',
                          '~': 'real'}[expr.prefix]
         else:
             expr.type = 'integer' # function return value
@@ -329,8 +332,8 @@ class ASTVisitorDetermineExpressionTypes(ASTVisitor):
             assert_type(expr.subscripts[0], 'integer')
             if not expr.identifier.type.startswith('array'):
                 raise ParseException(expr.identifier, 'Expected array')
-            # an added subscript turns eg. an array of integer into just an integer
-            expr.type = expr.identifier.type.replace('array of ', '')
+            # an added subscript turns eg. an integer array into just an integer
+            expr.type = expr.identifier.type.replace(' array', '')
         else:
             expr.type = expr.identifier.type
         return False

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -242,7 +242,7 @@ class ASTVisitorDetermineExpressionTypes(ASTVisitor):
                     elif 'any-array-variable' in param_descriptor:
                         pass
                     elif 'array-or-string-array-variable' in param_descriptor:
-                        if not passed_param.type in ('array-variable', 'string-array'):
+                        if not passed_param.type in ('integer array', 'string array'):
                             assert_type(passed_param, 'integer or string array')
                     elif 'string-array' in param_descriptor:
                         assert_type(passed_param, 'string array')
@@ -252,7 +252,7 @@ class ASTVisitorDetermineExpressionTypes(ASTVisitor):
                         assert_type(passed_param, 'real array')
                     elif 'key-id' in param_descriptor:
                         if not isinstance(passed_param, VarRef):
-                            raise ParseException(node, 'Expected key-id.')
+                            raise ParseException(node, 'Expected key id.')
                         passed_param.type = 'key-id'
                     elif 'real-value' in param_descriptor:
                         assert_type(passed_param, 'real')
@@ -330,7 +330,7 @@ class ASTVisitorDetermineExpressionTypes(ASTVisitor):
         self.visit_children(parent, expr, *args)
         if expr.subscripts:
             assert_type(expr.subscripts[0], 'integer')
-            if not expr.identifier.type.startswith('array'):
+            if not expr.identifier.type.endswith(' array'):
                 raise ParseException(expr.identifier, 'Expected array')
             # an added subscript turns eg. an integer array into just an integer
             expr.type = expr.identifier.type.replace(' array', '')


### PR DESCRIPTION
This was only valid when Extra syntax checks was enabled. Still, valid fix. While at it, also fix the fact that <array-or-string-array-variable> descriptor mistakenly also passed real arrays as valid, which wouldn't work in Kontakt. This affected all load/save array commands.

Also slightly improved the wording of the mismatched argument type exception message.