### PR TITLE
Extra compiler checks will check against a list of builtin functions which can return values for const variables

### DIFF
--- a/ksp_compiler3/ksp_builtins.py
+++ b/ksp_compiler3/ksp_builtins.py
@@ -22,12 +22,15 @@ keywords = set()
 string_typed_control_parameters = set()
 function_signatures = {}
 functions_with_forced_parenthesis = set()
+functions_with_constant_return = set() # Functions with return values that can be used for const variables
 
 data = {'variables': variables,
         'functions': functions,
         'keywords':  keywords,
         'string_typed_control_parameters': string_typed_control_parameters,
-        'functions_with_forced_parenthesis': functions_with_forced_parenthesis}
+        'functions_with_forced_parenthesis': functions_with_forced_parenthesis,
+        'functions_with_constant_return': functions_with_constant_return
+        }
 
 section = None
 #try:
@@ -51,6 +54,7 @@ for line in lines:
             name, params, return_type = m.group('name'), m.group('params'), m.group('return_type')
             params = [p.strip() for p in params.replace('<', '').replace('>', '').split(',') if p.strip()]
             function_signatures[name] = (params, return_type)
+
 
 # mapping from function_name to descriptive string
 functions = dict([(x.split('(')[0], x) for x in functions])

--- a/ksp_compiler3/ksp_builtins_data.py
+++ b/ksp_compiler3/ksp_builtins_data.py
@@ -1333,6 +1333,25 @@ zone_slice_start(<zone-id>, <slice-idx>):integer
 [functions_with_forced_parenthesis]
 mf_reset
 
+[functions_with_constant_return]
+abs
+acos
+asin
+atan
+by_marks
+by_track
+cos
+exp
+floor
+get_ui_id
+log
+lsb
+num_elements
+pow
+sin
+sqrt
+tan
+
 [keywords]
 _pgs_changed
 and

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -505,7 +505,7 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
             size = 1
 
         initial_value = None
-        if 'const' in node.modifiers:
+        if 'const' in node.modifiers and not ( isinstance(node.initial_value, Integer) or isinstance(node.initial_value, Real) ):
             # First need to check if the initial value is an NI constant
             init_expr = node.initial_value
             if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or (str(node.initial_value.function_name) in ksp_builtins.functions_with_constant_return)):

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -508,7 +508,7 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
         if 'const' in node.modifiers:
             # First need to check if the initial value is an NI constant
             init_expr = node.initial_value
-            if not (isinstance(init_expr, VarRef) and str(init_expr.identifier).upper() in ksp_builtins.variables):
+            if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or (str(node.initial_value.function_name) in ksp_builtins.functions)):
                 if not node.initial_value:
                     raise ParseException(node.variable, 'A constant value has to be assigned to the constant')
                 try:

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -505,7 +505,7 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
             size = 1
 
         initial_value = None
-        if 'const' in node.modifiers and not ( isinstance(node.initial_value, Integer) or isinstance(node.initial_value, Real) ):
+        if 'const' in node.modifiers and not (isinstance(node.initial_value, Integer) or isinstance(node.initial_value, Real)):
             # First need to check if the initial value is an NI constant
             init_expr = node.initial_value
             if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or (str(node.initial_value.function_name) in ksp_builtins.functions_with_constant_return)):

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -508,7 +508,7 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
         if 'const' in node.modifiers:
             # First need to check if the initial value is an NI constant
             init_expr = node.initial_value
-            if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or (str(node.initial_value.function_name) in ksp_builtins.functions)):
+            if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or (str(node.initial_value.function_name) in ksp_builtins.functions_with_constant_return)):
                 if not node.initial_value:
                     raise ParseException(node.variable, 'A constant value has to be assigned to the constant')
                 try:
@@ -519,7 +519,6 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
                         initial_value = test
                 except ValueUndefinedException:
                     raise ParseException(node.initial_value, 'Expression uses non-constant values or undefined constant variables')
-
         try:
             params = []
             for param in node.parameters:


### PR DESCRIPTION
Only some inbuilt functions can be used for const variables. See `ksp_builtins_data.py` for full list

Resolve #222 