### PR TITLE
Minor bug fix for comparing inbuilt functions with constant return

### DIFF
--- a/ksp_compiler3/ksp_ast.py
+++ b/ksp_compiler3/ksp_ast.py
@@ -292,10 +292,11 @@ class PropertyDef(Stmt):
 
 class DeclareStmt(Stmt):
 
-    def __init__(self, lexinfo, variable, modifiers, size=None, parameters=None, initial_value=None):
+    def __init__(self, lexinfo, variable, modifiers, persistence, size=None, parameters=None, initial_value=None):
         Stmt.__init__(self, lexinfo)
         self.variable = variable
         self.modifiers = modifiers
+        self.persistence = persistence
         self.size = size
         self.parameters = parameters or []
         self.initial_value = initial_value
@@ -334,6 +335,11 @@ class DeclareStmt(Stmt):
                 out.write(')')
             else:
                 out.write(str(initial_value))
+        if self.persistence:
+            for value in self.persistence:
+                out.write('\n' + str({  'pers'    :'make_persistent(', 
+                                        'instpers':'make_instr_persistent(',
+                                        'read'    :'read_persistent_var('}.get(value)) + '%s)' % self.variable)
         out.writeln()
 
     def get_childnodes(self):

--- a/ksp_compiler3/ksp_builtins.py
+++ b/ksp_compiler3/ksp_builtins.py
@@ -22,12 +22,15 @@ keywords = set()
 string_typed_control_parameters = set()
 function_signatures = {}
 functions_with_forced_parenthesis = set()
+functions_with_constant_return = set() # Functions with return values that can be used for const variables
 
 data = {'variables': variables,
         'functions': functions,
         'keywords':  keywords,
         'string_typed_control_parameters': string_typed_control_parameters,
-        'functions_with_forced_parenthesis': functions_with_forced_parenthesis}
+        'functions_with_forced_parenthesis': functions_with_forced_parenthesis,
+        'functions_with_constant_return': functions_with_constant_return
+        }
 
 section = None
 #try:
@@ -51,6 +54,7 @@ for line in lines:
             name, params, return_type = m.group('name'), m.group('params'), m.group('return_type')
             params = [p.strip() for p in params.replace('<', '').replace('>', '').split(',') if p.strip()]
             function_signatures[name] = (params, return_type)
+
 
 # mapping from function_name to descriptive string
 functions = dict([(x.split('(')[0], x) for x in functions])

--- a/ksp_compiler3/ksp_builtins_data.py
+++ b/ksp_compiler3/ksp_builtins_data.py
@@ -1333,6 +1333,25 @@ zone_slice_start(<zone-id>, <slice-idx>):integer
 [functions_with_forced_parenthesis]
 mf_reset
 
+[functions_with_constant_return]
+abs
+acos
+asin
+atan
+by_marks
+by_track
+cos
+exp
+floor
+get_ui_id
+log
+lsb
+num_elements
+pow
+sin
+sqrt
+tan
+
 [keywords]
 _pgs_changed
 and

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -505,7 +505,7 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
             size = 1
 
         initial_value = None
-        if 'const' in node.modifiers:
+        if 'const' in node.modifiers and not ( isinstance(node.initial_value, Integer) or isinstance(node.initial_value, Real) ):
             # First need to check if the initial value is an NI constant
             init_expr = node.initial_value
             if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or (str(node.initial_value.function_name) in ksp_builtins.functions_with_constant_return)):

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -505,10 +505,10 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
             size = 1
 
         initial_value = None
-        if 'const' in node.modifiers and not ( isinstance(node.initial_value, Integer) or isinstance(node.initial_value, Real) ):
+        if 'const' in node.modifiers:
             # First need to check if the initial value is an NI constant
             init_expr = node.initial_value
-            if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or (str(node.initial_value.function_name) in ksp_builtins.functions_with_constant_return)):
+            if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or ("function_name" in init_expr.__dict__ and str(init_expr.function_name) in ksp_builtins.functions_with_constant_return)):
                 if not node.initial_value:
                     raise ParseException(node.variable, 'A constant value has to be assigned to the constant')
                 try:

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -508,7 +508,7 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
         if 'const' in node.modifiers:
             # First need to check if the initial value is an NI constant
             init_expr = node.initial_value
-            if not (isinstance(init_expr, VarRef) and str(init_expr.identifier).upper() in ksp_builtins.variables):
+            if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or (str(node.initial_value.function_name) in ksp_builtins.functions)):
                 if not node.initial_value:
                     raise ParseException(node.variable, 'A constant value has to be assigned to the constant')
                 try:

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -508,7 +508,7 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
         if 'const' in node.modifiers:
             # First need to check if the initial value is an NI constant
             init_expr = node.initial_value
-            if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or (str(node.initial_value.function_name) in ksp_builtins.functions)):
+            if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or (str(node.initial_value.function_name) in ksp_builtins.functions_with_constant_return)):
                 if not node.initial_value:
                     raise ParseException(node.variable, 'A constant value has to be assigned to the constant')
                 try:
@@ -519,7 +519,6 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
                         initial_value = test
                 except ValueUndefinedException:
                     raise ParseException(node.initial_value, 'Expression uses non-constant values or undefined constant variables')
-
         try:
             params = []
             for param in node.parameters:

--- a/ksp_compiler3/ksp_parser.py
+++ b/ksp_compiler3/ksp_parser.py
@@ -25,7 +25,7 @@ import os.path
 
 reserved = (
     'FUNCTION', 'TASKFUNC', 'AND', 'OR', 'NOT', 'IF', 'TO', 'DOWNTO', 'ELSE', 'FOR', 'WHILE', 'DECLARE',
-    'SELECT', 'CASE', 'CONST', 'POLYPHONIC', 'END', 'LOCAL', 'GLOBAL', 'FAMILY', 'IMPORT', 'AS', 'PROPERTY',
+    'SELECT', 'CASE', 'CONST', 'POLYPHONIC', 'END', 'LOCAL', 'GLOBAL', 'PERS', 'INSTPERS', 'READ', 'FAMILY', 'IMPORT', 'AS', 'PROPERTY',
     'UI_LABEL', 'UI_BUTTON', 'UI_SWITCH', 'UI_SLIDER', 'UI_MENU', 'UI_VALUE_EDIT', 'UI_WAVEFORM', 'UI_WAVETABLE', 'UI_KNOB', 'UI_TABLE', 'UI_XY', 'CALL', 'STEP',
     'UI_TEXT_EDIT', 'UI_LEVEL_METER', 'UI_FILE_SELECTOR', 'UI_PANEL', 'UI_MOUSE_AREA', 'OVERRIDE',
 )
@@ -512,12 +512,12 @@ def p_functiondefs2(p):
         p[0] = [p[1]] + p[3]
 
 def p_declaration1(p):
-    'declaration           : DECLARE global-modifier-opt decl-modifier-opt ident args-opt initial-value-opt'
-    p[0] = DeclareStmt(p, variable=p[4], modifiers=p[2] + p[3], size=None, parameters=p[5], initial_value=p[6])
+    'declaration           : DECLARE global-modifier-opt persistences-opt decl-modifier-opt ident args-opt initial-value-opt'
+    p[0] = DeclareStmt(p, variable=p[5], modifiers=p[2] + p[4], persistence=p[3], size=None, parameters=p[6], initial_value=p[7])
 
 def p_declaration2(p):
-    'declaration           : DECLARE global-modifier-opt decl-modifier-opt ident array-size args-opt initial-array-opt'
-    p[0] = DeclareStmt(p, variable=p[4], modifiers=p[2] + p[3], size=p[5], parameters=p[6], initial_value=p[7])
+    'declaration           : DECLARE global-modifier-opt persistences-opt decl-modifier-opt ident array-size args-opt initial-array-opt'
+    p[0] = DeclareStmt(p, variable=p[5], modifiers=p[2] + p[4], persistence=p[3], size=p[6], parameters=p[7], initial_value=p[8])
 
 def p_family_declaration(p):
     'family-declaration    : FAMILY ident NEWLINE stmts-opt END FAMILY'
@@ -535,6 +535,38 @@ def p_global_modifier_opt(p):
 def p_global_modifier_opt_empty(p):
     'global-modifier-opt   : empty'
     p[0] = []
+
+def p_persistences_opt(p):
+    'persistences-opt      : persistences'
+    p[0] = p[1]
+
+def p_pers_opt_empty(p):
+    'persistences-opt      : empty'
+    p[0] = []
+
+def p_persistences(p):
+    'persistences          : persistence'
+    if p[1] is None:
+        p[0] = []
+    else:
+        p[0] = [p[1]]
+
+def p_persistences_more(p):
+    'persistences          : persistence persistences'
+    if p[1] is None:
+        p[0] = p[2]
+    else:
+        p[0] = [p[1]] + p[2]
+
+def p_persistence(p):
+    '''persistence         : PERS
+                           | INSTPERS
+                           | READ'''
+    p[0] = p[1]
+
+def p_persistence_empty(p):
+    'persistence           : dummy'
+    p[0] = None
 
 def p_decl_modifier_opt(p):
     '''decl-modifier-opt     : CONST

--- a/ksp_compiler3/preprocessor_plugins.py
+++ b/ksp_compiler3/preprocessor_plugins.py
@@ -85,7 +85,7 @@ def post_macro_functions(lines):
 	handleMultidimensionalArrays(lines)
 	handleListBlocks(lines)
 	handleOpenSizeArrays(lines)
-	handlePersistence(lines)
+	#handlePersistence(lines)
 	handleLists(lines)
 	handleUIFunctions(lines)
 	handleStringArrayInitialisation(lines)
@@ -1053,6 +1053,7 @@ def handleStringArrayInitialisation(lines):
 	replaceLines(lines, newLines)
 
 #=================================================================================================
+'''Note: Persistence handling now evaluated in the AST
 def handlePersistence(lines):
 	""" Simple adds make_persistent() or read_perisitent_var() lines when the pers or read keywords are found. """
 	newLines = collections.deque()
@@ -1085,7 +1086,7 @@ def handlePersistence(lines):
 		newLines.append(lines[i])
 
 	replaceLines(lines, newLines)
-
+'''
 #=================================================================================================
 class IterateMacro(object):
 	def __init__(self, macroName, minVal, maxVal, step, direction, line):

--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -8,6 +8,7 @@ import sys
 import re
 import threading
 import webbrowser
+import time
 
 sys.path.append(os.path.dirname(__file__))
 sys.path.append(os.path.join(os.path.dirname(__file__), 'ksp_compiler3'))
@@ -147,6 +148,7 @@ class CompileKspThread(threading.Thread):
     def run(self, *args):
         global last_compiler
 
+        init_compile_time = time.perf_counter()
         view = self.view
         code = view.substr(sublime.Region(0, view.size()))
         filepath = view.file_name()
@@ -184,6 +186,7 @@ class CompileKspThread(threading.Thread):
                 last_compiler = self.compiler
                 code = self.compiler.compiled_code
                 code = code.replace('\r', '')
+                print("final_compile_time: ", time.perf_counter() - init_compile_time)
                 if self.compiler.output_file:
                     if not os.path.isabs(self.compiler.output_file):
                         self.compiler.output_file = os.path.join(self.base_path, self.compiler.output_file)


### PR DESCRIPTION
Some objects in the AST can have a function_name member with no value, causing it to fail the inbuilt functions comparison