### PR TITLE
Added workflow file for automatic testing on commits pushed to master

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,29 @@
+name: Run tests.py with Unittest
+
+on: 
+  push:
+    branches: [master]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ply
+      - name: Test with Unittest
+        run: |
+          cd ksp_compiler3
+          python -m unittest "tests.py"


### PR DESCRIPTION
Only tests on 3.8 (ST4), 3.3.6 (ST3) is not supported for ubuntu. Test will fail as read_file_func is incorrect (fixed in https://github.com/nojanath/SublimeKSP/pull/230). Also `testBasicMacroInliningPartOfParameterNameInsideString` will fail, but this is a known bug.