### PR TITLE
Handle event_pars during parsing, checking against list of builtins.

### DIFF
--- a/ksp_compiler3/ksp_ast_processing.py
+++ b/ksp_compiler3/ksp_ast_processing.py
@@ -13,7 +13,7 @@
 # GNU General Public License for more details.
 
 from ksp_ast import *
-from ksp_builtins import string_typed_control_parameters
+from ksp_builtins import string_typed_control_parameters, control_parameters, event_parameters
 #import io
 
 def stripNone(L):
@@ -37,29 +37,56 @@ def flatten(L):
         return L
     return list(flatten_iter(L))
 
-def handle_set_control_par(control, parameter, value):
-    remap = {'X': 'POS_X', 'Y': 'POS_Y', 'MAX': 'MAX_VALUE', 'MIN': 'MIN_VALUE', 'DEFAULT': 'DEFAULT_VALUE'}
-    cp = parameter.identifier.upper()
-    cp = '$CONTROL_PAR_%s' % remap.get(cp, cp)
-    control_par = VarRef(parameter.lexinfo, ID(parameter.lexinfo, cp))
-    if cp in string_typed_control_parameters:
-        func_name = 'set_control_par_str'
-    else:
-        func_name = 'set_control_par'
-    return FunctionCall(control.lexinfo, ID(control.lexinfo, func_name),
-                        parameters=[control, control_par, value], is_procedure=True)
+def handle_set_par(control, parameter, value):
+    # for converting integers to IDs. e.g e -> 4 := x
+    if type(parameter) == Integer:
+        parameter = ID(parameter.lexinfo, str(parameter))
 
-def handle_get_control_par(control, parameter):
     remap = {'X': 'POS_X', 'Y': 'POS_Y', 'MAX': 'MAX_VALUE', 'MIN': 'MIN_VALUE', 'DEFAULT': 'DEFAULT_VALUE'}
     cp = parameter.identifier.upper()
     cp = '$CONTROL_PAR_%s' % remap.get(cp, cp)
-    control_par = VarRef(parameter.lexinfo, ID(parameter.lexinfo, cp))
-    if cp in string_typed_control_parameters:
-        func_name = 'get_control_par_str'
-    else:
-        func_name = 'get_control_par'
-    return FunctionCall(control.lexinfo, ID(control.lexinfo, func_name),
-                        parameters=[control, control_par], is_procedure=False)
+    if cp in control_parameters:
+        control_par = VarRef(parameter.lexinfo, ID(parameter.lexinfo, cp))
+        if cp in string_typed_control_parameters:
+            func_name = 'set_control_par_str'
+        else:
+            func_name = 'set_control_par'
+        return FunctionCall(control.lexinfo, ID(control.lexinfo, func_name),
+                            parameters=[control, control_par, value], is_procedure=True)
+
+    event_p = '$EVENT_PAR_%s' % parameter.identifier.upper()
+    if event_p in event_parameters:
+        event_par = VarRef(parameter.lexinfo, ID(parameter.lexinfo, event_p))
+        func_name = 'set_event_par'
+        return FunctionCall(control.lexinfo, ID(control.lexinfo, func_name),
+                            parameters=[control, event_par, value], is_procedure=True)
+
+    raise Exception("%s is not a valid control_par/event_par" % parameter.identifier)
+
+def handle_get_par(control, parameter):
+    if type(parameter) == Integer:
+        parameter = ID(parameter.lexinfo, str(parameter))
+
+    remap = {'X': 'POS_X', 'Y': 'POS_Y', 'MAX': 'MAX_VALUE', 'MIN': 'MIN_VALUE', 'DEFAULT': 'DEFAULT_VALUE'}
+    cp = parameter.identifier.upper()
+    cp = '$CONTROL_PAR_%s' % remap.get(cp, cp)
+    if cp in control_parameters:
+        control_par = VarRef(parameter.lexinfo, ID(parameter.lexinfo, cp))
+        if cp in string_typed_control_parameters:
+            func_name = 'get_control_par_str'
+        else:
+            func_name = 'get_control_par'
+        return FunctionCall(control.lexinfo, ID(control.lexinfo, func_name),
+                            parameters=[control, control_par], is_procedure=False)
+
+    event_p = '$EVENT_PAR_%s' % parameter.identifier.upper()
+    if event_p in event_parameters:
+        event_par = VarRef(parameter.lexinfo, ID(parameter.lexinfo, event_p))
+        func_name = 'get_event_par'
+        return FunctionCall(control.lexinfo, ID(control.lexinfo, func_name),
+                            parameters=[control, event_par], is_procedure=False)
+
+    raise Exception("%s is not a valid control_par/event_par" % parameter.identifier)
 
 class VariableNotDeclaredException(ParseException):
     pass

--- a/ksp_compiler3/ksp_builtins.py
+++ b/ksp_compiler3/ksp_builtins.py
@@ -19,14 +19,20 @@ import pkgutil
 variables = set()
 functions = set()
 keywords = set()
+control_parameters = set()
 string_typed_control_parameters = set()
+engine_parameters = set()
+event_parameters = set()
 function_signatures = {}
 functions_with_forced_parenthesis = set()
 
 data = {'variables': variables,
         'functions': functions,
         'keywords':  keywords,
+        'control_parameters': control_parameters,
         'string_typed_control_parameters': string_typed_control_parameters,
+        'engine_parameters': engine_parameters,
+        'event_parameters' : event_parameters,
         'functions_with_forced_parenthesis': functions_with_forced_parenthesis}
 
 section = None
@@ -51,6 +57,17 @@ for line in lines:
             name, params, return_type = m.group('name'), m.group('params'), m.group('return_type')
             params = [p.strip() for p in params.replace('<', '').replace('>', '').split(',') if p.strip()]
             function_signatures[name] = (params, return_type)
+
+        if section == 'variables':
+            m = re.match(r'(?P<control_par>\$CONTROL_PAR_\w+?)|(?P<engine_par>\$ENGINE_PAR_\w+?)|(?P<event_par>\$EVENT_PAR_\w+?)', line)
+            if m:
+                control_par, engine_par, event_par = m.group('control_par'), m.group('engine_par'), m.group('event_par')
+                if control_par:
+                    control_parameters.add(line)
+                elif engine_par:
+                    engine_parameters.add(line)
+                elif event_par:
+                    event_parameters.add(line)
 
 # mapping from function_name to descriptive string
 functions = dict([(x.split('(')[0], x) for x in functions])

--- a/ksp_compiler3/ksp_parser.py
+++ b/ksp_compiler3/ksp_parser.py
@@ -292,7 +292,7 @@ def p_stmt(p):
                            | while-stmt NEWLINE
                            | for-stmt NEWLINE
                            | select-stmt NEWLINE
-                           | set-ui-par-stmt NEWLINE'''
+                           | set-par-stmt NEWLINE'''
     p[0] = p[1]
 
 def p_stmt_empty(p):
@@ -585,13 +585,15 @@ def p_array_size(p):
     'array-size            : LBRACK expression RBRACK'
     p[0] = p[2]
 
-def p_set_ui_par_stmt(p):
-    'set-ui-par-stmt       : varref RIGHTARROW ident ASSIGN expression'
-    p[0] = handle_set_control_par(p[1], p[3], p[5])
+def p_set_par_stmt(p):
+    '''set-par-stmt        : varref RIGHTARROW ident ASSIGN expression
+                           | varref RIGHTARROW literal ASSIGN expression'''
+    p[0] = handle_set_par(p[1], p[3], p[5])
 
-def p_get_ui_par_expr(p):
-    'get-ui-par-expr       : varref RIGHTARROW ident'
-    p[0] = handle_get_control_par(p[1], p[3])
+def p_get_par_expr(p):
+    '''get-par-expr        : varref RIGHTARROW ident
+                           | varref RIGHTARROW literal'''
+    p[0] = handle_get_par(p[1], p[3])
 
 def p_subscripts(p):
     'subscripts            : LBRACK expression more-subscripts-opt RBRACK'
@@ -685,7 +687,7 @@ def p_expression_other(p):
     '''expression        : literal
                          | varref
                          | function-call
-                         | get-ui-par-expr'''
+                         | get-par-expr'''
     p[0] = p[1]
 
 def p_ident(p):


### PR DESCRIPTION
event_pars and control_pars are defined in builtins. 

When parsing (in ksp_parser.py), the parameter is compared against builtin pars. If it fails to evaluate as a control_par, then attempts to evaluate as an event_par, failing that, an Exception is generated