### PR TITLE
Remove "Raise Error on Empty 'if' or 'case' Statements" option

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -86,13 +86,6 @@
 					},
 					{
 						"command": "ksp_global_setting_toggle",
-						"args": {"setting": "ksp_signal_empty_ifcase", "default": true},
-						"caption": "Raise Error on Empty 'if' or 'case' Statements",
-						"mnemonic": "R",
-						"id": "signal_empty_ifcase"
-					},
-					{
-						"command": "ksp_global_setting_toggle",
 						"args": {"setting": "ksp_play_sound", "default": false},
 						"caption": "Play Sound When Compilation Finishes",
 						"mnemonic": "S",

--- a/ksp_compiler3/ksp_compiler.py
+++ b/ksp_compiler3/ksp_compiler.py
@@ -550,7 +550,7 @@ class ASTModifierCombineCallbacks(ASTModifierBase):
     def __init__(self, ast):
         ASTModifierBase.__init__(self, modify_expressions=True)
         self.traverse(ast, parent_funciton=None, function_params=[], parent_families=[])
-    
+
     def modifyModule(self, node, *args, **kwargs):
         callbacks = {}
         for b in node.blocks:
@@ -1628,14 +1628,13 @@ def strip_import_nckp_function_from_source(lines):
             line_obj.command = re.sub(r'[^\r\n]', '', ls_line)
 
 class KSPCompiler(object):
-    def __init__(self, source, basedir, compact=True, compactVars=False, read_file_func=default_read_file_func, extra_syntax_checks=False, optimize=False, check_empty_compound_statements=False, add_compiled_date_comment=False):
+    def __init__(self, source, basedir, compact=True, compactVars=False, read_file_func=default_read_file_func, extra_syntax_checks=False, optimize=False, add_compiled_date_comment=False):
         self.source = source
         self.basedir = basedir
         self.compact = compact
         self.compactVars = compactVars
         self.read_file_func = read_file_func
         self.optimize = optimize
-        self.check_empty_compound_statements = check_empty_compound_statements
         self.add_compiled_date_comment = add_compiled_date_comment
         self.extra_syntax_checks = extra_syntax_checks or optimize
         self.abort_requested = False
@@ -1913,7 +1912,6 @@ class KSPCompiler(object):
 
             do_extra = self.extra_syntax_checks
             do_optim = do_extra and self.optimize
-            do_emptycheck = self.check_empty_compound_statements and not do_optim
             #      description                   function                                                                           condition     time-weight
             tasks = [
                  ('scanning and importing code', lambda: self.do_imports_and_convert_to_line_objects(),                             True,             1),
@@ -1947,7 +1945,6 @@ class KSPCompiler(object):
                  ('removing unused functions',   lambda: comp_extras.ASTModifierRemoveUnusedFunctions(self.module, used_functions), do_optim,         1),
                  ('removing unused variables',   lambda: comp_extras.ASTVisitorFindUsedVariables(self.module, used_variables),      do_optim,         1),
                  ('removing unused variables',   lambda: comp_extras.ASTModifierRemoveUnusedVariables(self.module, used_variables), do_optim,         1),
-                 ('checking empty if-stmts',     lambda: comp_extras.ASTVisitorCheckNoEmptyIfCaseStatements(self.module),           do_emptycheck,    1),
                  ('compact variable names',      self.compact_names,                                                                self.compactVars, 1),
                  ('generate code',               self.generate_compiled_code,                                                       True,             1),
             ]
@@ -2061,7 +2058,6 @@ if __name__ == "__main__":
         read_file_func=read_file_func,
         extra_syntax_checks=args.extra_syntax_checks,
         optimize=args.optimize,
-        check_empty_compound_statements=False,
         add_compiled_date_comment=(not args.nocompiledate))
     compiler.compile()
 

--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -346,21 +346,6 @@ class ASTVisitorDetermineExpressionTypes(ASTVisitor):
             expr.type = expr.identifier.type
         return False
 
-class ASTVisitorCheckNoEmptyIfCaseStatements(ASTVisitor):
-    def __init__(self, ast):
-        ASTVisitor.__init__(self, visit_expressions=False)
-        self.traverse(ast)
-
-    def visitIfStmt(self, parent, node, *args):
-        (condition, stmts) = node.condition_stmts_tuples[0]
-        if len(stmts) == 0:
-            raise ParseException(node, "Warning: due to a KSP bug, an empty 'if' statement is equivalent to invoking the exit function! Please make sure the body of your 'if' statement is not empty!")
-
-    def visitSelectStmt(self, parent, node, *args):
-        for ((start, stop), stmts) in node.range_stmts_tuples:
-            if len(stmts) == 0:
-                raise ParseException(start, "Warning: due to a KSP bug, an empty 'case' statement is equivalent to invoking the exit function. Please make sure the body of your 'case' statement is not empty!")
-
 class ASTVisitorCheckStatementExprTypes(ASTVisitor):
     def __init__(self, ast):
         ASTVisitor.__init__(self, visit_expressions=False)
@@ -860,9 +845,5 @@ def check_code(module, optimize=False, check_empty_compound_statements=False, ca
 
         yield ('progress', 'optimizing - removing unused variables', 95)
         ASTModifierRemoveUnusedVariables(module, used_variables)
-
-    if check_empty_compound_statements:
-        yield ('progress', 'checking existance of empty compound statements', 98)
-        ASTVisitorCheckNoEmptyIfCaseStatements(module)
 
     yield ('completed', module)

--- a/ksp_compiler3/tests.py
+++ b/ksp_compiler3/tests.py
@@ -22,9 +22,9 @@ import unittest
 def default_read_file_func(filepath):
     return open(filepath, 'r').read()
 
-def do_compile(code, remove_preprocessor_vars=False, compact=True, compactVars=False, comments_on_expansion=True, read_file_func=default_read_file_func, extra_syntax_checks=True, optimize=False, check_empty_compound_statements=False, add_compiled_date_comment=False):
+def do_compile(code, remove_preprocessor_vars=False, compact=True, compactVars=False, comments_on_expansion=True, read_file_func=default_read_file_func, extra_syntax_checks=True, optimize=False, add_compiled_date_comment=False):
     #line_map = {}
-    compiler = KSPCompiler(code, None,compact=compact,compactVars=compactVars, read_file_func=read_file_func, extra_syntax_checks=extra_syntax_checks, optimize=optimize, check_empty_compound_statements=check_empty_compound_statements, add_compiled_date_comment=add_compiled_date_comment)
+    compiler = KSPCompiler(code, None,compact=compact,compactVars=compactVars, read_file_func=read_file_func, extra_syntax_checks=extra_syntax_checks, optimize=optimize, add_compiled_date_comment=add_compiled_date_comment)
     compiler.compile()
     output_code = compiler.compiled_code
     if remove_preprocessor_vars and optimize == False:
@@ -708,7 +708,7 @@ class TypeChecks(unittest.TestCase):
                 declare x
                 message(num_elements(x))
             end on'''
-        self.assertRaises(ParseException, do_compile, code) 
+        self.assertRaises(ParseException, do_compile, code)
 
     def testParametersWithDifferentTypesToMessage(self):
         code = '''

--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -161,7 +161,6 @@ class CompileKspThread(threading.Thread):
         compactVars = settings.get('ksp_compact_variables', False)
         check = settings.get('ksp_extra_checks', True)
         optimize = settings.get('ksp_optimize_code', False)
-        check_empty_compound_statements = settings.get('ksp_signal_empty_ifcase', True)
         add_compiled_date_comment = settings.get('ksp_add_compiled_date', True)
         should_play_sound = settings.get('ksp_play_sound', False)
 
@@ -178,7 +177,6 @@ class CompileKspThread(threading.Thread):
                                                      read_file_func=self.read_file_function,
                                                      extra_syntax_checks=check,
                                                      optimize=optimize and check,
-                                                     check_empty_compound_statements=check_empty_compound_statements,
                                                      add_compiled_date_comment=add_compiled_date_comment)
             if self.compiler.compile(callback=self.compile_on_progress):
                 last_compiler = self.compiler
@@ -332,7 +330,6 @@ class KspGlobalSettingToggleCommand(sublime_plugin.ApplicationCommand):
             "ksp_compact_variables" : "Compact Variables",
             "ksp_extra_checks" : "Extra Syntax Checks",
             "ksp_optimize_code" : "Optimize Compiled Code",
-            "ksp_signal_empty_ifcase" : "Raise Error on Empty 'if' or 'case' Statements",
             "ksp_add_compiled_date" : "Add Compilation Date/Time Comment",
             "ksp_comment_inline_functions" : "Insert Comments When Expanding Functions",
             "ksp_play_sound" : "Play Sound When Compilation Finishes"
@@ -355,12 +352,9 @@ class KspGlobalSettingToggleCommand(sublime_plugin.ApplicationCommand):
     def is_enabled(self, setting, default):
         extra_checks = bool(sublime.load_settings("KSP.sublime-settings").get("ksp_extra_checks", default))
         optim_code = bool(sublime.load_settings("KSP.sublime-settings").get("ksp_optimize_code", default))
-        signal_empty = not (extra_checks and optim_code)
 
         if setting == "ksp_optimize_code":
             return extra_checks
-        elif setting == "ksp_signal_empty_ifcase":
-            return signal_empty
         else:
             return True
 


### PR DESCRIPTION
Because nobody is developing for versions older than Kontakt 4.2 these days