### PR TITLE
Added parse error and test for variables declared outside 'on init' 

### DIFF
--- a/ksp_compiler3/ksp_compiler_extras.py
+++ b/ksp_compiler3/ksp_compiler_extras.py
@@ -545,6 +545,9 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
         else:
             control_type = None
 
+        if type(parent) == Callback and parent.name != 'init':
+            raise ParseException(node, 'Variables may only be declared inside the "on init" callback!')
+
         is_constant = ('const' in node.modifiers and initial_value is not None)
         is_polyphonic = 'polyphonic' in node.modifiers
         symbol_table[name.lower()] = Variable(node.variable, size, params, control_type, is_constant, is_polyphonic, initial_value)

--- a/ksp_compiler3/tests.py
+++ b/ksp_compiler3/tests.py
@@ -396,6 +396,13 @@ class CompactOutput(unittest.TestCase):
         # if the variables have different prefixes they shouldn't create a clash after compaction
 
 class VariableDeclarationCheck(unittest.TestCase):
+    def testVariableDeclaredOutsideInit(self):
+        code = '''on note
+            declare x := 5
+        end on
+        '''
+        self.assertRaises(ParseException, do_compile, code)
+
     def testVariableIntDeclaration(self):
         code = '''on init
             declare x := 5


### PR DESCRIPTION
This error is handled after function/taskfunc local variable declaration