### PR TITLE
Minor change to parser for real numbers detection

### DIFF
--- a/ksp_compiler3/ksp_parser.py
+++ b/ksp_compiler3/ksp_parser.py
@@ -101,7 +101,7 @@ def t_RIGHTARROW(t):
     return t
 
 def t_REAL(t):
-    r'(\d*\.\d+)([eE]-?\d+)?'
+    r'(\d*\.\d*)([eE]-?\d+)?'
     return t
 
 def t_ID(t):


### PR DESCRIPTION
commit 0cdc9a9ac3ee2ac49f950896433761e62461f34a enforced real numbers to include number after decimal. Kept syntax change, but changed parser regex so old scripts can still be parsed.