### PR TITLE
Improve multiple script compilation, compiler message log

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -91,7 +91,7 @@
 						"command": "ksp_global_setting_toggle",
 						"args": {"setting": "ksp_combine_callbacks", "default": false},
 						"caption": "Combine Duplicate Callbacks",
-						"mnemonic": "B",
+						"mnemonic": "b",
 						"id": "combine_callbacks"
 					},
 					{"caption": "-"}, //separator


### PR DESCRIPTION
Silently skip scripts without save_compiled_source pragma instead of erroring out
Don't assign syntax in a loop across all open views on compilation
Add log_message() which prints to console AND ST's status line, use it consistently in ksp_plugin.py
Fix mnemonic for Combine Duplicate Callbacks menu command