### PR TITLE
PR revert forced real syntax

### DIFF
--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -50,7 +50,7 @@ contexts:
       comment: Literate On
       captures:
         1: keyword.other.source.ksp
-    - match: '(\s+-|(?<=[=,{}()])-)?((0x)[0-9a-fA-F]*|[0-9][0-9a-fA-F]*[hH]|b[0-9.]+|[0-9.]+b|(\d*\.?\d*)([eE]-?\d+)?)\b'
+    - match: '(\s+-|(?<=[=,{}()])-)?((0x)[0-9a-fA-F]*|[0-9][0-9a-fA-F]*[hH]|b[0-9.]+|[0-9.]+b|(\d*\.?\d*)([eE]-?\d+)?)\b\.*'
       comment: Numerical constant
       scope: constant.numeric.source.ksp
     - match: "[,.()\\[\\]]"

--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -50,7 +50,7 @@ contexts:
       comment: Literate On
       captures:
         1: keyword.other.source.ksp
-    - match: '(\s+-|(?<=[=,{}()])-)?((0x)[0-9a-fA-F]*|[0-9][0-9a-fA-F]*[hH]|b[0-9.]+|[0-9.]+b|(\d*\.?\d+)([eE]-?\d+)?)\b'
+    - match: '(\s+-|(?<=[=,{}()])-)?((0x)[0-9a-fA-F]*|[0-9][0-9a-fA-F]*[hH]|b[0-9.]+|[0-9.]+b|(\d*\.?\d*)([eE]-?\d+)?)\b'
       comment: Numerical constant
       scope: constant.numeric.source.ksp
     - match: "[,.()\\[\\]]"

--- a/ksp_compiler3/ksp_parser.py
+++ b/ksp_compiler3/ksp_parser.py
@@ -101,7 +101,7 @@ def t_RIGHTARROW(t):
     return t
 
 def t_REAL(t):
-    r'(\d*\.\d+)([eE]-?\d+)?'
+    r'(\d*\.\d*)([eE]-?\d+)?'
     return t
 
 def t_ID(t):


### PR DESCRIPTION
Revert forced real syntax. Allows real numbers to be declared with the number after optional. 
Exponential notation still works

Syntax colouring works for real numbers without number after point
`4.` will now correctly syntax highlight