### PR TITLE
Appends snippets to the list of inbuilt autocompletes

### DIFF
--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -392,13 +392,14 @@ class KSPCompletions(sublime_plugin.EventListener):
                 bc.extend(builtin_compl_funcs)
                 compl.extend(bc)
 
-            compl.extend(builtin_snippets)
+            if sublime_version >= 4000:
+                compl.extend(builtin_snippets)
         #compl = self.unique(compl)
 
         if sublime_version >= 4000:
             sublime.CompletionList(compl, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
-
-        return (compl, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
+        else:
+            return (compl, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
 
 
 class NumericSequenceCommand(sublime_plugin.TextCommand):

--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -287,10 +287,12 @@ for f in functions:
     else:
         args_str = ''
 
+    function_details = "<b>Args</b>: %s  |  <b>Returns</b>: [%s]" % ((function_signatures[f][0]), function_signatures[f][1])
+
     completion = ["%s\tfunction" % (f), "%s%s" % (f,args_str)]
 
     if sublime_version >= 4000:
-        builtin_compl_funcs.append(sublime.CompletionItem(trigger=f, annotation='function', completion=f+args_str, completion_format= sublime.COMPLETION_FORMAT_SNIPPET, kind=sublime.KIND_FUNCTION))
+        builtin_compl_funcs.append(sublime.CompletionItem(trigger=f, annotation='function', completion=f+args_str, details=function_details, completion_format= sublime.COMPLETION_FORMAT_SNIPPET, kind=sublime.KIND_FUNCTION))
     else:
         builtin_compl_funcs.append(tuple(completion))
         builtin_compl_funcs.sort()

--- a/snippets/callback.sublime-snippet
+++ b/snippets/callback.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-on ${1}
+on ${1:callback}
 	${0}
 end on
 ]]></content>


### PR DESCRIPTION
Snippets are parsed using Element Tree. 
Any future snippets will be automatically added

Fix #278 

Minor note: Make sure that the first variable in a snippet has a tag (otherwise autocomplete menu remains open)