### PR TITLE
Append snippets to autocomplete menu

### DIFF
--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -392,11 +392,11 @@ class KSPCompletions(sublime_plugin.EventListener):
                 bc.extend(builtin_compl_funcs)
                 compl.extend(bc)
 
-            compl.extend(builtin_snippets)
-        #compl = self.unique(compl)
-
         if sublime_version >= 4000:
+            compl.extend(builtin_snippets)
             sublime.CompletionList(compl, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
+        else:
+            compl = self.unique(compl)
 
         return (compl, sublime.INHIBIT_WORD_COMPLETIONS | sublime.INHIBIT_EXPLICIT_COMPLETIONS)
 

--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -287,10 +287,12 @@ for f in functions:
     else:
         args_str = ''
 
+    function_details = "<b>Args</b>: %s  |  <b>Returns</b>: [%s]" % ((function_signatures[f][0]), function_signatures[f][1])
+
     completion = ["%s\tfunction" % (f), "%s%s" % (f,args_str)]
 
     if sublime_version >= 4000:
-        builtin_compl_funcs.append(sublime.CompletionItem(trigger=f, annotation='function', completion=f+args_str, completion_format= sublime.COMPLETION_FORMAT_SNIPPET, kind=sublime.KIND_FUNCTION))
+        builtin_compl_funcs.append(sublime.CompletionItem(trigger=f, annotation='function', completion=f+args_str, details=function_details, completion_format= sublime.COMPLETION_FORMAT_SNIPPET, kind=sublime.KIND_FUNCTION))
     else:
         builtin_compl_funcs.append(tuple(completion))
         builtin_compl_funcs.sort()

--- a/snippets/callback.sublime-snippet
+++ b/snippets/callback.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-on ${1}
+on ${1:callback}
 	${0}
 end on
 ]]></content>


### PR DESCRIPTION
Note: In ST4 snippets don't get automatically added to autocompletes. (caused ST4 to miss snippets)

### Updates for ST4
 - `sublime-snippets` are parsed into CompletionItems.
 - Autocompletes are made into CompletionItems, which form the CompletionList. 
 - Autocomplete items are categorised as snippets, variables and functions. Function types show details on input args and return types.
 
Fix #278 

![image](https://user-images.githubusercontent.com/88255410/209868630-a61a5664-88f6-46ae-9d6c-9c1709fbc457.png)
