### PR TITLE
Fix messages.json file - missing commas

### DIFF
--- a/messages.json
+++ b/messages.json
@@ -46,12 +46,12 @@
     "1.10.4": "messages/1.10.4.txt",
     "1.10.5": "messages/1.10.5.txt",
     "1.10.6": "messages/1.10.6.txt",
-    "1.11.0": "messages/1.11.0.txt"
-    "1.11.1": "messages/1.11.1.txt"
-    "1.11.2": "messages/1.11.2.txt"
-    "1.12.0": "messages/1.12.0.txt"
-    "1.12.1": "messages/1.12.1.txt"
-    "1.12.2": "messages/1.12.2.txt"
-    "1.13.0": "messages/1.13.0.txt"
+    "1.11.0": "messages/1.11.0.txt",
+    "1.11.1": "messages/1.11.1.txt",
+    "1.11.2": "messages/1.11.2.txt",
+    "1.12.0": "messages/1.12.0.txt",
+    "1.12.1": "messages/1.12.1.txt",
+    "1.12.2": "messages/1.12.2.txt",
+    "1.13.0": "messages/1.13.0.txt",
     "1.13.1": "messages/1.13.1.txt"
 }


### PR DESCRIPTION
No end of line commas added for last several versions.
Not sure, but may prevent message popping up when new version is installed via package control.