### PR TITLE
Fixed defines not working inside literate/iterate_post_macro

### DIFF
--- a/ksp_compiler3/ksp_compiler.py
+++ b/ksp_compiler3/ksp_compiler.py
@@ -1834,6 +1834,12 @@ class KSPCompiler(object):
             normal_lines, callback_lines = expand_macros(self.lines, self.macros, 0, True)
             self.lines = normal_lines + callback_lines
 
+        # convert any strings from the macro expansion back into placeholders to allow iter_macros to substitute strings
+        convert_strings_to_placeholders(self.lines)
+
+        # run define subs a final time, catch returned cache just as a formality
+        self.define_cache = substituteDefines(self.lines, self.define_cache)
+
 
     def examine_pragmas(self, code, namespaces):
         '''Examine pragmas within code'''


### PR DESCRIPTION
Added a final define substitution phase after the literate/iterate_post_macro steps. This will ensure define constants used inside code generated from there will work.

This could be considered a bugfix for the feature as defines are expected to always work in any context.