### PR TITLE
Improve workflow of sKSP compiler running from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # SublimeKSP
 
-A Sublime Text plugin for working with and compiling KSP (Kontakt Script Processor) code. Works with Sublime Text versions 3 and 4.
+A Sublime Text 3/4 plugin for working with and compiling KSP (Kontakt Script Processor) code.
 
 ### Changes
-This fork is based on [Nils Liberg's official SublimeKSP plugin, v1.11](http://nilsliberg.se/ksp/), and supports Kontakt versions 5.6 and up. However, there are a number of additions and changes:
+This fork is based on [Nils Liberg's official SublimeKSP plugin, v1.11](http://nilsliberg.se/ksp/), and supports all Kontakt versions.
+However, there are a number of additions and changes:
 
-* Additions to the preprocessor allowing for UI arrays, new macro types and more
 * Available in Package Control, which supports automatic updates
 * Updates to the syntax highlighting
 * Support for Creator Tools GUI Designer
-* `default_syntax.py` has since been removed, since this can be set elsewhere
+* Numerous additions to the preprocessor, allowing for UI arrays, new macro types and much more
 * See the [Added Features](https://github.com/nojanath/SublimeKSP/wiki/Added-Features) section of the [Wiki](https://github.com/nojanath/SublimeKSP/wiki) for more information
 
 ### Installation
@@ -18,17 +18,51 @@ This fork is based on [Nils Liberg's official SublimeKSP plugin, v1.11](http://n
 * After installing Package Control and restarting Sublime Text:
   * Open the Command Palette from the Tools menu, or by pressing <kbd>Cmd</kbd><kbd>Shift</kbd><kbd>P</kbd> (macOS) or <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>P</kbd> (Windows)
   * Type "Install Package"
-  * Type "KSP" or "Kontakt" and select "KSP (Kontakt Script Processor)"
+  * Type "KSP" and select "KSP (Kontakt Script Processor)"
   * Press <kbd>Enter</kbd> to install
   * Restart Sublime Text
 
 ### Manual Installation
 
- * To use features of SublimeKSP before official package releases, clone this repository into your `Sublime Text/Packages/` folder
+ * To use features of SublimeKSP before official package releases, clone this repository into your `Packages` folder
  * This folder can be located in Sublime Text by selecting `Preferences > Browse Packages` from the main menu
  * Ensure that the root folder is named `SublimeKSP`
  * After pulling the latest changes, reload Sublime Text
  * If you wish to pull features without restarting Sublime Text, we recommend installing [Automatic​Package​Reloader](https://packagecontrol.io/packages/AutomaticPackageReloader)
+
+### Running From Command Line
+
+SublimeKSP compiler can also be ran from command line, by simply executing `ksp_compiler.py` with the appropriate source (and optionally output) file path(s),
+along with optional compiler switches.
+For this, you need to use the manual installation of SublimeKSP, in order to have direct access to `ksp_compiler.py` file. To execute a compilation of a file,
+it is as simple as typing:
+
+```
+> python ksp_compiler.py "<source-file-path>"
+```
+
+However, various compiler options from SublimeKSP's Tools menu are also available. All of them are set to false if not used,
+and by including them in the command line, they are set to true:
+
+```
+ksp_compiler.py [-h] [-c] [-v] [-e] [-o] [-t] [-d] source_file [output_file]
+
+positional arguments:
+  source_file
+  output_file
+
+optional arguments:
+  -h, --help                   show this help message and exit
+  -c, --compact                remove indents and empty lines in compiled code
+  -v, --compact_variables      shorten and obfuscate variable names in compiled code
+  -e, --extra_syntax_checks    additional syntax checks during compilation
+  -o, --optimize               optimize the compiled code
+  -t, --add_compile_date       adds the date and time comment atop the compiled code
+  -d, --combine_callbacks      combines duplicate callbacks - but not functions or macros
+
+
+> python ksp_compiler.py -c -e -o "<source-file-path>" "<target-file-path"
+```
 
 ### Updates
 * Updates to the plugin will be automatically installed via Package Control.

--- a/ksp_compiler3/ksp_compiler.py
+++ b/ksp_compiler3/ksp_compiler.py
@@ -2082,12 +2082,12 @@ if __name__ == "__main__":
 
     # parse command line arguments
     arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument('--compact', dest='compact', action='store_true', default='false', help='Minimize whitespace in compiled code')
-    arg_parser.add_argument('--compact_variables', dest='compact_variables', action='store_true', default='false', help='Shorten and obfuscate variable names')
-    arg_parser.add_argument('--extra_syntax_checks', dest='extra_syntax_checks', action='store_true', default='false', help='Additional syntax checks')
-    arg_parser.add_argument('--optimize', dest='optimize', action='store_true', default='false', help='Optimize the generated code')
-    arg_parser.add_argument('--nocompiledate', dest='add_compiled_date_comment', action='store_true', default='true', help='Remove the compiler date argument')
-    arg_parser.add_argument('--combine_callbacks', dest='combine_callbacks', action='store_true', default='true', help='Combines callbacks (not including functions or macros)')
+    arg_parser.add_argument('--compact', dest='compact', action='store_true', default=False, help='Remove indents and empty lines in compiled code')
+    arg_parser.add_argument('--compact_variables', dest='compact_variables', action='store_true', default=False, help='Shorten and obfuscate variable names in compiled code')
+    arg_parser.add_argument('--extra_syntax_checks', dest='extra_syntax_checks', action='store_true', default=True, help='Additional syntax checks during compilation')
+    arg_parser.add_argument('--optimize', dest='optimize', action='store_true', default=False, help='Optimize the compiled code')
+    arg_parser.add_argument('--add_compile_date', dest='add_compile_date', action='store_true', default=True, help='Adds the date and time comment atop the compiled code')
+    arg_parser.add_argument('--combine_callbacks', dest='combine_callbacks', action='store_true', default=False, help='Combines duplicate callbacks (not functions or macros)')
     arg_parser.add_argument('source_file', type=FileType('r', encoding='latin-1'))
     arg_parser.add_argument('output_file', type=FileType('w', encoding='latin-1'), nargs='?')
     args = arg_parser.parse_args()
@@ -2122,7 +2122,7 @@ if __name__ == "__main__":
         read_file_func=read_file_func,
         extra_syntax_checks=args.extra_syntax_checks,
         optimize=args.optimize,
-        add_compiled_date_comment=(not args.nocompiledate))
+        add_compiled_date_comment=(args.add_compile_date))
     compiler.compile()
 
     # write the compiled code to output

--- a/ksp_compiler3/ksp_compiler.py
+++ b/ksp_compiler3/ksp_compiler.py
@@ -2054,12 +2054,12 @@ if __name__ == "__main__":
 
     # parse command line arguments
     arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument('--compact', dest='compact', action='store_true', default=False, help='Remove indents and empty lines in compiled code')
-    arg_parser.add_argument('--compact_variables', dest='compact_variables', action='store_true', default=False, help='Shorten and obfuscate variable names in compiled code')
-    arg_parser.add_argument('--extra_syntax_checks', dest='extra_syntax_checks', action='store_true', default=True, help='Additional syntax checks during compilation')
-    arg_parser.add_argument('--optimize', dest='optimize', action='store_true', default=False, help='Optimize the compiled code')
-    arg_parser.add_argument('--add_compile_date', dest='add_compile_date', action='store_true', default=True, help='Adds the date and time comment atop the compiled code')
-    arg_parser.add_argument('--combine_callbacks', dest='combine_callbacks', action='store_true', default=False, help='Combines duplicate callbacks (not functions or macros)')
+    arg_parser.add_argument('-c', '--compact', dest='compact', action='store_true', default=False, help='remove indents and empty lines in compiled code')
+    arg_parser.add_argument('-v', '--compact_variables', dest='compact_variables', action='store_true', default=False, help='shorten and obfuscate variable names in compiled code')
+    arg_parser.add_argument('-e', '--extra_syntax_checks', dest='extra_syntax_checks', action='store_true', default=False, help='additional syntax checks during compilation')
+    arg_parser.add_argument('-o', '--optimize', dest='optimize', action='store_true', default=False, help='optimize the compiled code')
+    arg_parser.add_argument('-t', '--add_compile_date', dest='add_compile_date', action='store_true', default=False, help='adds the date and time comment atop the compiled code')
+    arg_parser.add_argument('-d', '--combine_callbacks', dest='combine_callbacks', action='store_true', default=False, help='combines duplicate callbacks - but not functions or macros')
     arg_parser.add_argument('source_file', type=FileType('r', encoding='latin-1'))
     arg_parser.add_argument('output_file', type=FileType('w', encoding='latin-1'), nargs='?')
     args = arg_parser.parse_args()

--- a/ksp_compiler3/ksp_compiler.py
+++ b/ksp_compiler3/ksp_compiler.py
@@ -32,6 +32,7 @@ import time
 from preprocessor_plugins import pre_macro_functions, macro_iter_functions, substituteDefines, post_macro_iter_functions, post_macro_functions
 import json
 import copy
+import utils
 
 variable_prefixes = '$%@!?~'
 
@@ -115,35 +116,6 @@ def prefix_ID_with_ns(id, namespaces, function_parameter_names=None, force_prefi
         return ksp_ast.ID(id.lexinfo, identifier=prefix_with_ns(str(id), namespaces, function_parameter_names, force_prefixing))
     else:
         return id
-
-def split_args(arg_string, line):
-    '''converts eg. "x, y*(1+z), z" into a list ['x', 'y*(1+z)', 'z']'''
-    if arg_string.strip() == '':
-        return []
-    args = []
-    cur_arg = ''
-    unmatched_left_paren = 0
-    double_quote_on = False
-
-    for idx, ch in enumerate(arg_string + ','):    # extra ',' to include the last argument
-        # square brackets are also checked as there may be commas in them (for properties/2D arrays)
-        if ch == '\"' and (idx == 0 or arg_string[idx - 1] != '\\'):
-            double_quote_on = not double_quote_on
-        elif ch in ['(', '[']:
-            unmatched_left_paren += 1
-        elif ch in [')', ']']:
-            unmatched_left_paren -= 1
-        if ch == ',' and unmatched_left_paren == 0 and not double_quote_on:
-            cur_arg = cur_arg.strip()
-            if not cur_arg:
-                raise ParseException(line, 'Syntax error: empty argument in function call %s!' % arg_string)
-            args.append(cur_arg)
-            cur_arg = ''
-        else:
-            cur_arg += ch
-    if unmatched_left_paren:
-        raise ParseException(line, 'Error: unmatched parenthesis in function call %s!' % arg_string)
-    return args
 
 class ExceptionWithMessage(Exception):
     _message = None
@@ -504,7 +476,7 @@ def expand_macros(lines, macros, level=0, replace_raw=True):
 
                 macro = name2macro[macro_name]
                 if args:
-                    args = split_args(args[1:-1], line)
+                    args = utils.split_args(args[1:-1], line)
                 else:
                     args = []
 

--- a/ksp_compiler3/preprocessor_plugins.py
+++ b/ksp_compiler3/preprocessor_plugins.py
@@ -21,7 +21,6 @@ import copy
 import re
 import math
 import collections
-import ksp_compiler
 from simple_eval import SimpleEval
 import time
 from time import strftime, localtime

--- a/ksp_compiler3/utils.py
+++ b/ksp_compiler3/utils.py
@@ -1,0 +1,44 @@
+# ksp-compiler - a compiler for the Kontakt script language
+# Copyright (C) 2011  Nils Liberg
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version:
+# http://www.gnu.org/licenses/gpl-2.0.html
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+import sys
+
+def split_args(arg_string, line):
+    '''converts eg. "x, y*(1+z), z" into a list ['x', 'y*(1+z)', 'z']'''
+    if arg_string.strip() == '':
+        return []
+    args = []
+    cur_arg = ''
+    unmatched_left_paren = 0
+    double_quote_on = False
+
+    for idx, ch in enumerate(arg_string + ','):    # extra ',' to include the last argument
+        # square brackets are also checked as there may be commas in them (for properties/2D arrays)
+        if ch == '\"' and (idx == 0 or arg_string[idx - 1] != '\\'):
+            double_quote_on = not double_quote_on
+        elif ch in ['(', '[']:
+            unmatched_left_paren += 1
+        elif ch in [')', ']']:
+            unmatched_left_paren -= 1
+        if ch == ',' and unmatched_left_paren == 0 and not double_quote_on:
+            cur_arg = cur_arg.strip()
+            if not cur_arg:
+                raise ParseException(line, 'Syntax error: empty argument in function call %s!' % arg_string)
+            args.append(cur_arg)
+            cur_arg = ''
+        else:
+            cur_arg += ch
+    if unmatched_left_paren:
+        raise ParseException(line, 'Error: unmatched parenthesis in function call %s!' % arg_string)
+    return args


### PR DESCRIPTION
Default values for compiler switches didn't work at all (they were strings instead of bools)
Made default values of all compiler arguments false - simply using a compile switch will set it to true
Inverted behavior of ex --nocompiledate (now --add_compile_date) switch
All compile switches now have a single letter shorthand
Removed circular import of ksp_compiler.py in preprocessor_plugins.py
Updated README with info about how to compile from command line