### PR TITLE
Prevent multiple preprocessor variable declarations

### DIFF
--- a/compiler/ksp_ast.py
+++ b/compiler/ksp_ast.py
@@ -775,7 +775,6 @@ class ID(Expr):
         return '%s%s' % (self.prefix, self.identifier)
 
     def __repr__(self):
-        #raise Exception('')
         return '%s%s' % (self.prefix, self.identifier)
 
     def get_childnodes(self):

--- a/compiler/ksp_ast.py
+++ b/compiler/ksp_ast.py
@@ -775,7 +775,7 @@ class ID(Expr):
         return '%s%s' % (self.prefix, self.identifier)
 
     def __repr__(self):
-        raise Exception('')
+        #raise Exception('')
         return '%s%s' % (self.prefix, self.identifier)
 
     def get_childnodes(self):

--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -537,7 +537,8 @@ class ASTModifierBase(ksp_ast_processing.ASTModifier):
 
 class ASTModifierCombineCallbacks(ASTModifierBase):
     '''Combines callbacks by generating a dictionary of used CBs and extending existing ones with lines in the duplicate CB'''
-    def __init__(self, ast):
+    def __init__(self, ast, combine_callbacks):
+        self.combine_callbacks = combine_callbacks
         ASTModifierBase.__init__(self, modify_expressions=True)
         self.traverse(ast, parent_function=None, function_params=[], parent_families=[])
 
@@ -554,9 +555,9 @@ class ASTModifierCombineCallbacks(ASTModifierBase):
                 cb_key = b.name + ui_name
 
                 if cb_key in callbacks:
+                    if not self.combine_callbacks:
+                        raise ksp_ast.ParseException(b, "Callback already declared! (Combine Duplicate Callbacks is currently disabled)")
                     children = b.get_childnodes()
-                    if b.name == 'init':
-                        children = children[4:] # Removes preprocessor variables (concat_it, string_it etc.) from duplicate init CBs
                     if b.variable:
                         children = children[1:] # Removes ui_name from children to prevent duplicate CBs
                     callbacks[cb_key].lines.extend(children) # Extend the existing CB with lines from the duplicate
@@ -1996,7 +1997,7 @@ class KSPCompiler(object):
 
                  ('convert lines to code block', lambda: self.convert_lines_to_code(),                                              True,                   1),
                  ('parse code',                  lambda: self.parse_code(),                                                         True,                   1),
-                 ('combining callbacks',         lambda: ASTModifierCombineCallbacks(self.module),                                  self.combine_callbacks, 1),
+                 ('combining callbacks',         lambda: ASTModifierCombineCallbacks(self.module, self.combine_callbacks),          True,                   1),
                  ('various tasks',               lambda: ASTModifierFixReferencesAndFamilies(self.module, self.lines),              True,                   1),
                  ('add variable name prefixes',  lambda: ASTModifierFixPrefixesIncludingLocalVars(self.module),                     True,                   1),
                  ('inline functions',            lambda: ASTModifierFunctionExpander(self.module),                                  True,                   1),

--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -556,7 +556,7 @@ class ASTModifierCombineCallbacks(ASTModifierBase):
 
                 if cb_key in callbacks:
                     if not self.combine_callbacks:
-                        raise ksp_ast.ParseException(b, "Callback already declared! (Combine Duplicate Callbacks is currently disabled)")
+                        raise ksp_ast.ParseException(b, "This callback has already been declared! Either remove the duplicate, or enable the Combine Duplicate Callbacks option.")
                     children = b.get_childnodes()
                     if b.variable:
                         children = children[1:] # Removes ui_name from children to prevent duplicate CBs

--- a/compiler/preprocessor_plugins.py
+++ b/compiler/preprocessor_plugins.py
@@ -465,8 +465,9 @@ def handleArrayConcat(lines):
 		elif line.startswith("on"):
 			if re.search(initRe, line):
 				newLines.append(lines[lineIdx])
-				newLines.append(lines[lineIdx].copy("declare concat_it"))
-				newLines.append(lines[lineIdx].copy("declare concat_offset"))
+				if not (any(l.command == "declare concat_i" for l in newLines) or any(l.command == "declare concat_offset" for l in newLines)): # Only add preprocessor variable if not previously declared
+					newLines.append(lines[lineIdx].copy("declare concat_it"))
+					newLines.append(lines[lineIdx].copy("declare concat_offset"))
 				continue
 		newLines.append(lines[lineIdx])
 	replaceLines(lines, newLines)
@@ -901,7 +902,8 @@ def handleLists(lines):
 					raise ParseException(lines[lineIdx], "list_add() can only be used in the init callback!\n")
 			newLines.append(lines[lineIdx])
 			if addInitVar:
-				newLines.append(lines[lineIdx].copy("declare list_it"))
+				if not any(l.command == "declare list_it" for l in newLines): # Only add preprocessor variable if not previously declared
+					newLines.append(lines[lineIdx].copy("declare list_it"))
 				addInitVar = False
 			continue
 		else:
@@ -1020,7 +1022,8 @@ def handleSanitizeExitCommand(lines):
 		if line.startswith("on"):
 			if re.search(initRe, line):
 				newLines.append(lines[i])
-				newLines.append(lines[i].copy("declare sksp_dummy"))
+				if not any(l.command == "declare sksp_dummy" for l in newLines): # Only add preprocessor variable if not previously declared
+					newLines.append(lines[i].copy("declare sksp_dummy"))
 				continue
 
 		if line == "exit":
@@ -1044,7 +1047,8 @@ def handleStringArrayInitialisation(lines, placeholders):
 		if line.startswith("on"):
 			if re.search(initRe, line):
 				newLines.append(lines[i])
-				newLines.append(lines[i].copy("declare string_it"))
+				if not any(l.command == "declare string_it" for l in newLines): # Only add preprocessor variable if not previously declared
+					newLines.append(lines[i].copy("declare string_it"))
 				continue
 		if line.startswith("declare"):
 			m = re.search(stringArrayRe, line)
@@ -1386,7 +1390,8 @@ def handleUIArrays(lines):
 		if line.startswith("on"):
 			if re.search(initRe, line):
 				newLines.append(lines[lineNum])
-				newLines.append(lines[lineNum].copy("declare preproc_i"))
+				if not any(l.command == "declare preproc_i" for l in newLines): # Only add preprocessor variable if not previously declared
+					newLines.append(lines[lineNum].copy("declare preproc_i"))
 				continue
 		elif line.startswith("decl"):
 			m = re.search(uiArrayRe, line)


### PR DESCRIPTION
Raise error if there is a duplicate callback when "Combine Duplicate Callbacks" is disabled.

Removed the exception caused when trying to representing IDs (I think this has been left from previous debugging). Its really annoying