### PR TITLE
Fix Combine Callbacks Removing Empty Statements

### DIFF
--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -661,7 +661,7 @@ class ASTModifierCombineCallbacks(ASTModifierBase):
 
         if self.combine_callbacks:
             # Removes the CBs with no lines from node.blocks
-            node.blocks = [b for b in node.blocks if b.lines != []]
+            node.blocks = [b for b in node.blocks if (isinstance(b, ksp_ast.Callback) and b.lines != []) or not isinstance(b, ksp_ast.Callback)]
 
 class ASTModifierFixReferencesAndFamilies(ASTModifierBase):
     '''Travel through AST and modify nodes to native KSP'''

--- a/compiler/tests.py
+++ b/compiler/tests.py
@@ -187,6 +187,35 @@ end on'''
         expected_output = [l.strip() for l in expected_output.split('\n') if l]
         self.assertEqual(output, expected_output)
 
+    def testCombineCallbacksWithEmptyFunction(self):
+        code = '''
+        on init
+            declare ui_button Button
+        end on
+
+        function foo()
+        end function
+
+        on ui_control (Button)
+            call foo()
+        end on
+        '''
+        expected_output = '''
+        on init
+          declare ui_button $Button
+        end on
+
+        function foo
+        end function
+
+        on ui_control($Button)
+          call foo
+        end on'''
+        output = do_compile(code, combine_callbacks=True, remove_preprocessor_vars=True)
+        output = [l.strip() for l in output.split('\n') if l]
+        expected_output = [l.strip() for l in expected_output.split('\n') if l]
+        self.assertEqual(output, expected_output)
+
 class Precedence(unittest.TestCase):
     def testBinaryPrecedence1(self):
         code = '''


### PR DESCRIPTION
Ensure that other statements (functions, families, properties etc.) are not removed if Combined Callbacks enable and statements are empty 
Fix #324
Added Unittest for combine callbacks with empty statement (function)