### PR TITLE
Don't join threads when attempting to compile while another compile is running

### DIFF
--- a/KScript Dark.tmTheme
+++ b/KScript Dark.tmTheme
@@ -28,7 +28,7 @@
 				<key>gutterForeground</key>
 				<string>#999</string>
 				<key>invisibles</key>
-				<string>#333</string>
+				<string>#444</string>
 				<key>lineHighlight</key>
 				<string>#222</string>
 				<key>selection</key>

--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -54,8 +54,8 @@ class CompileKspCommand(sublime_plugin.ApplicationCommand):
     def run(self, *args, **kwargs):
         # wait until any previous thread is finished
         if self.thread and self.thread.is_alive():
-            utils.log_message('Waiting for earlier compilation to finish...')
-            self.thread.join()
+            utils.log_message('Another compilation is in progress! Please wait until it is finished.')
+            return False
 
         # find the view containing the code to compile
         view = sublime.active_window().active_view()


### PR DESCRIPTION
This was crashing Sublime Text if compile was attempted before parsing step. Instead, show a message that compilation is in progress and should be waited out.

Minor adjustment to "invisibles" color in KScript Dark theme