### PR TITLE
Adds a get_ui_id() wrapper if the setter variable is a ui_control

### DIFF
--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -1527,11 +1527,13 @@ class ASTModifierFixPrefixesAndFixControlPars(ASTModifierFixPrefixes):
         if function_name in ksp_builtins.functions and not node.using_call_keyword and \
            (function_name.startswith('set_control_par') or function_name.startswith('get_control_par')) and \
            len(node.parameters) > 0 and isinstance(node.parameters[0], ksp_ast.VarRef) and str(node.parameters[0].identifier).lower() in ui_variables:
-
             # then wrap the UI variable in a get_ui_id call, eg. myknob is converted into get_ui_id(myknob)
             func_call_inner = ksp_ast.FunctionCall(node.lexinfo, ksp_ast.ID(node.parameters[0].lexinfo, 'get_ui_id'), [node.parameters[0]], is_procedure=False)
+            # If last parameter is a ui_variable then add get_ui_id() wrapper
+            if function_name.startswith('set_control_par') and isinstance(node.parameters[2], ksp_ast.VarRef) and str(node.parameters[2].identifier).lower() in ui_variables:
+                func_call_outer = ksp_ast.FunctionCall(node.lexinfo, ksp_ast.ID(node.parameters[2].lexinfo, 'get_ui_id'), [node.parameters[2]], is_procedure=False)
+                node.parameters[2] = func_call_outer
             node            = ksp_ast.FunctionCall(node.lexinfo, node.function_name, [func_call_inner] + node.parameters[1:], is_procedure=node.is_procedure)
-
         if node.is_procedure:
             return [node]
         else:


### PR DESCRIPTION
This should only affect `CONTROL_PAR_PARENT_PANEL` as this is the only control_par that assigns to a ui control.

Fix #335 