### PR TITLE
Fixed get UI id() for set control par

### DIFF
--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -1521,8 +1521,8 @@ class ASTModifierFixPrefixesAndFixControlPars(ASTModifierFixPrefixes):
            len(node.parameters) > 0 and isinstance(node.parameters[0], ksp_ast.VarRef) and str(node.parameters[0].identifier).lower() in ui_variables:
             # then wrap the UI variable in a get_ui_id call, eg. myknob is converted into get_ui_id(myknob)
             func_call_inner = ksp_ast.FunctionCall(node.lexinfo, ksp_ast.ID(node.parameters[0].lexinfo, 'get_ui_id'), [node.parameters[0]], is_procedure=False)
-            # If last parameter is a ui_variable then add get_ui_id() wrapper
-            if function_name.startswith('set_control_par') and isinstance(node.parameters[2], ksp_ast.VarRef) and str(node.parameters[2].identifier).lower() in ui_variables:
+            # If last parameter is a ui_variable and is trying to add to parent_panel then add get_ui_id() wrapper
+            if function_name.startswith('set_control_par') and isinstance(node.parameters[2], ksp_ast.VarRef) and str(node.parameters[1]) == "$CONTROL_PAR_PARENT_PANEL" and str(node.parameters[2].identifier).lower() in ui_variables:
                 func_call_outer = ksp_ast.FunctionCall(node.lexinfo, ksp_ast.ID(node.parameters[2].lexinfo, 'get_ui_id'), [node.parameters[2]], is_procedure=False)
                 node.parameters[2] = func_call_outer
             node            = ksp_ast.FunctionCall(node.lexinfo, node.function_name, [func_call_inner] + node.parameters[1:], is_procedure=node.is_procedure)

--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -1522,7 +1522,7 @@ class ASTModifierFixPrefixesAndFixControlPars(ASTModifierFixPrefixes):
             # then wrap the UI variable in a get_ui_id call, eg. myknob is converted into get_ui_id(myknob)
             func_call_inner = ksp_ast.FunctionCall(node.lexinfo, ksp_ast.ID(node.parameters[0].lexinfo, 'get_ui_id'), [node.parameters[0]], is_procedure=False)
             # If last parameter is a ui_variable and is trying to add to parent_panel then add get_ui_id() wrapper
-            if function_name.startswith('set_control_par') and isinstance(node.parameters[2], ksp_ast.VarRef) and str(node.parameters[1]) == "$CONTROL_PAR_PARENT_PANEL" and str(node.parameters[2].identifier).lower() in ui_variables:
+            if str(node.parameters[1]) == "$CONTROL_PAR_PARENT_PANEL" and str(node.parameters[2].identifier).lower() in ui_variables:
                 func_call_outer = ksp_ast.FunctionCall(node.lexinfo, ksp_ast.ID(node.parameters[2].lexinfo, 'get_ui_id'), [node.parameters[2]], is_procedure=False)
                 node.parameters[2] = func_call_outer
             node            = ksp_ast.FunctionCall(node.lexinfo, node.function_name, [func_call_inner] + node.parameters[1:], is_procedure=node.is_procedure)

--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -1522,7 +1522,7 @@ class ASTModifierFixPrefixesAndFixControlPars(ASTModifierFixPrefixes):
             # then wrap the UI variable in a get_ui_id call, eg. myknob is converted into get_ui_id(myknob)
             func_call_inner = ksp_ast.FunctionCall(node.lexinfo, ksp_ast.ID(node.parameters[0].lexinfo, 'get_ui_id'), [node.parameters[0]], is_procedure=False)
             # If last parameter is a ui_variable and is trying to add to parent_panel then add get_ui_id() wrapper
-            if str(node.parameters[1]) == "$CONTROL_PAR_PARENT_PANEL" and str(node.parameters[2].identifier).lower() in ui_variables:
+            if function_name.startswith('set_control_par') and str(node.parameters[1]) == "$CONTROL_PAR_PARENT_PANEL" and str(node.parameters[2].identifier).lower() in ui_variables:
                 func_call_outer = ksp_ast.FunctionCall(node.lexinfo, ksp_ast.ID(node.parameters[2].lexinfo, 'get_ui_id'), [node.parameters[2]], is_procedure=False)
                 node.parameters[2] = func_call_outer
             node            = ksp_ast.FunctionCall(node.lexinfo, node.function_name, [func_call_inner] + node.parameters[1:], is_procedure=node.is_procedure)

--- a/compiler/tests.py
+++ b/compiler/tests.py
@@ -1910,6 +1910,12 @@ class ControlParTest(unittest.TestCase):
             control_reference := get_ui_id(myvalue)
             control_reference->value := 10
             CONTROL_REFERENCE->value := 10   { test case-sensitivity }
+
+            declare ui_panel Engine.mainKnobMod(0,128)
+            declare ui_panel Engine.mainLabel(0,128)
+            declare ui_panel Engine.modBackgroundLabel(1,1)
+            Engine.modBackgroundLabel -> picture_state := Engine.mainKnobMod
+            Engine.modBackgroundLabel -> parent_panel := Engine.mainLabel
         end on
 
         function make_settings(fam)
@@ -1927,8 +1933,10 @@ class ControlParTest(unittest.TestCase):
         self.assertTrue('set_control_par_str(get_ui_id($myfam__myknob),$CONTROL_PAR_TEXT,"text")' in output)
         self.assertTrue('message(get_control_par(get_ui_id($myfam__myknob),$CONTROL_PAR_POS_X))' in output)
         self.assertTrue('message(get_control_par_str(get_ui_id($myfam__myknob),$CONTROL_PAR_TEXT))' in output)
+        self.assertTrue('set_control_par(get_ui_id($Engine__modBackgroundLabel),$CONTROL_PAR_PARENT_PANEL,get_ui_id($Engine__mainLabel))' in output)
         # ... but not on this one (since it uses an integer variable and not a UI variable):
         self.assertTrue('set_control_par($control_reference,$CONTROL_PAR_VALUE,10)' in output)
+        self.assertTrue('set_control_par(get_ui_id($Engine__modBackgroundLabel),$CONTROL_PAR_PICTURE_STATE,$Engine__mainKnobMod)' in output)
 
 class TestSubscripts(unittest.TestCase):
     def testSubscripts1(self):


### PR DESCRIPTION
Only adds `get_ui_id()` for last param if `CONTROL_PAR_PARENT_PANEL` and last variable is ui_control