### PR TITLE
Fix get/set_event_par() by generating functions_with_constant_return

### DIFF
--- a/compiler/ksp_builtins.py
+++ b/compiler/ksp_builtins.py
@@ -26,6 +26,7 @@ event_parameters = set()
 function_signatures = {}
 functions_with_forced_parentheses = set()
 functions_with_constant_return = set() # Functions with return values that can be used for const variables
+functions_evaluated_with_optimize_code = set() # Functions that can be evaluated during compiling when optimize_code is enabled
 
 sKSP_preprocessor_variables = ("sksp_dummy", "string_it", "list_it", "concat_it", "concat_offset", "preproc_i")
 
@@ -38,6 +39,7 @@ data = {'variables': variables,
         'event_parameters' : event_parameters,
         'functions_with_forced_parentheses': functions_with_forced_parentheses,
         'functions_with_constant_return': functions_with_constant_return,
+        'functions_evaluated_with_optimize_code': functions_evaluated_with_optimize_code,
         'sKSP_variables' : sKSP_preprocessor_variables,
         }
 
@@ -64,6 +66,9 @@ for line in lines:
                 function_signatures[name].append((params, return_type))
             else:
                 function_signatures[name] = [(params, return_type)]
+
+            if name not in functions_with_constant_return and return_type == "real" or return_type == "integer":
+                functions_with_constant_return.add(name)
 
         if section == 'variables':
             m = re.match(r'(?P<control_par>\$CONTROL_PAR_\w+?)|(?P<engine_par>\$ENGINE_PAR_\w+?)|(?P<event_par>\$EVENT_PAR_\w+?)', line)

--- a/compiler/ksp_builtins_data.py
+++ b/compiler/ksp_builtins_data.py
@@ -1401,24 +1401,16 @@ mf_get_channel
 mf_get_command
 mf_get_last_filename
 
-[functions_with_constant_return]
+[functions_evaluated_with_optimize_code]
 abs
-acos
-asin
-atan
+in_range
+sh_left
+sh_right
 by_marks
-by_track
-cos
-exp
-floor
-get_ui_id
-log
-lsb
-num_elements
-pow
-sin
-sqrt
-tan
+int_to_real
+real
+real_to_int
+int
 
 [keywords]
 _pgs_changed

--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -1513,13 +1513,12 @@ class ASTModifierFixPrefixesAndFixControlPars(ASTModifierFixPrefixes):
 
         function_name = node.function_name.identifier
 
-        # if it's an event_par which does not give a constant return then raise error e.g ticks_to_ms(x) -> volume := 49
+        # if it's an event_par which does not have a constant return then raise error
         if function_name in ksp_builtins.functions and not node.using_call_keyword                      \
            and (function_name.startswith('set_event_par') or function_name.startswith('get_event_par')) \
            and isinstance(node.parameters[0], ksp_ast.FunctionCall)                                     \
            and str(node.parameters[0].function_name) not in ksp_builtins.functions_with_constant_return:
-
-            raise ksp_ast.ParseException(node.parameters[0], '"%s" is not a valid as a function that can use arrow notation!' % node.parameters[0].function_name)
+            raise ksp_ast.ParseException(node.parameters[0], '"%s" is not a valid as a function that can be used with set/get event_pars!' % node.parameters[0].function_name)
 
         # if it's a builtin function that sets or gets a control par and the first parameter is not an integer ID, but rather a UI variable
         if function_name in ksp_builtins.functions and not node.using_call_keyword                           \

--- a/compiler/ksp_compiler_extras.py
+++ b/compiler/ksp_compiler_extras.py
@@ -529,7 +529,8 @@ class ASTVisitorCheckDeclarations(ASTVisitor):
                 raise ParseException(node.variable, 'A constant must have a value assigned!')
             init_expr = node.initial_value
             # First need to check if the initial value is an NI constant
-            if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or ("function_name" in init_expr.__dict__ and str(init_expr.function_name) in ksp_builtins.functions_with_constant_return)):
+            if not (isinstance(init_expr, VarRef) and (str(init_expr.identifier).upper() in ksp_builtins.variables) or ("function_name" in init_expr.__dict__ \
+            and str(init_expr.function_name) in ksp_builtins.functions_with_constant_return) and str(init_expr.function_name) not in ksp_builtins.functions_evaluated_with_optimize_code):
                 try:
                     test = evaluate_expression(node.initial_value)
                     if test == None:


### PR DESCRIPTION
Close #350 

This was being caused by certain functions not being considered to return a constant. Reworked the set `functions_with_constant_return` to be generated when creating builtins. It adds any function from the set `functions` which can return a 'real' or 'integer'. I believe this is how Kontakt is able to determine if the expression is valid within `get/set_event_par` or `get/set_engine_par`.

As a side effect, `optimize_code` would no longer evaluate expressions (abs, in_range, sh_left, sh_right, by_marks, int_to_real, real, real_to_int, int), so added a new builtins set, `functions_evaluated_with_optimize_code` that bypasses these builtins to allow for evaluation.
