### PR TITLE
Make error reporting in utils.split_args() actually work

### DIFF
--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -204,9 +204,11 @@ class ExceptionWithMessage(Exception):
 class ParseException(ExceptionWithMessage):
     '''Parse Exceptions for parse errors raised before AST lex/yacc parsing'''
 
-    def __init__(self, line, message):
-        assert(isinstance(line, Line))
-        msg = "%s\n%s\n\n%s" % (message, str(line).strip(), line.get_locations_string())
+    def __init__(self, line, message, no_traceback = False):
+        if no_traceback:
+            utils.disable_traceback()
+
+        msg = "%s\n\n%s\n\n%s" % (message, str(line).strip(), line.get_locations_string())
         Exception.__init__(self, msg)
         self.line = line
         self.message = msg

--- a/compiler/utils.py
+++ b/compiler/utils.py
@@ -21,6 +21,12 @@ try:
 except ImportError:
     has_sublime_api = False
 
+def disable_traceback():
+    if sys.version_info < (3, 6, 2):
+        sys.tracebacklimit = None
+    else:
+        sys.tracebacklimit = 0
+
 def split_args(arg_string, line):
     '''converts eg. "x, y*(1+z), z" into a list ['x', 'y*(1+z)', 'z']'''
     if arg_string.strip() == '':
@@ -41,13 +47,15 @@ def split_args(arg_string, line):
         if ch == ',' and unmatched_left_paren == 0 and not double_quote_on:
             cur_arg = cur_arg.strip()
             if not cur_arg:
-                raise ParseException(line, 'Syntax error: empty argument in function call %s!' % arg_string)
+                from ksp_compiler import ParseException
+                raise ParseException(line, 'Empty argument in function call %s!' % arg_string, True)
             args.append(cur_arg)
             cur_arg = ''
         else:
             cur_arg += ch
     if unmatched_left_paren:
-        raise ParseException(line, 'Error: unmatched parenthesis in function call %s!' % arg_string)
+        from ksp_compiler import ParseException
+        raise ParseException(line, 'Unmatched parenthesis in function call %s!' % arg_string, True)
     return args
 
 def log_message(msg):


### PR DESCRIPTION
Add an option to ksp_compiler.ParseException to disable traceback