### PR TITLE
Fix get_ui_id() being added to non-UI controls when setting parent panel

### DIFF
--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -1525,15 +1525,14 @@ class ASTModifierFixPrefixesAndFixControlPars(ASTModifierFixPrefixes):
         # if it's a builtin function that sets or gets a control par and the first parameter is not an integer ID, but rather a UI variable
         if function_name in ksp_builtins.functions and not node.using_call_keyword                           \
            and (function_name.startswith('set_control_par') or function_name.startswith('get_control_par'))  \
-           and len(node.parameters) > 0 and isinstance(node.parameters[0], ksp_ast.VarRef)                   \
-           and str(node.parameters[0].identifier).lower() in ui_variables:
+           and len(node.parameters) > 0 and str(node.parameters[0].identifier).lower() in ui_variables:
 
             # then wrap the UI variable in a get_ui_id call, eg. myknob is converted into get_ui_id(myknob)
             func_call_inner = ksp_ast.FunctionCall(node.lexinfo, ksp_ast.ID(node.parameters[0].lexinfo, 'get_ui_id'), [node.parameters[0]], is_procedure = False)
 
             # If last parameter is a ui_variable and is trying to add to parent_panel then add get_ui_id() wrapper
             if function_name.startswith('set_control_par') and str(node.parameters[1]).endswith("PARENT_PANEL")  \
-               and isinstance(node.parameters[2], ksp_ast.VarRef):
+               and str(node.parameters[2].identifier).lower() in ui_variables:
 
                 func_call_outer = ksp_ast.FunctionCall(node.lexinfo, ksp_ast.ID(node.parameters[2].lexinfo, 'get_ui_id'), [node.parameters[2]], is_procedure = False)
                 node.parameters[2] = func_call_outer

--- a/compiler/tests.py
+++ b/compiler/tests.py
@@ -1917,6 +1917,11 @@ class ControlParTest(unittest.TestCase):
             declare ui_panel Engine.panel
             Engine.label -> picture_state := Engine.knob
             Engine.label -> parent_panel := Engine.panel
+
+            declare ui_button A[5]
+            declare ui_panel Panel[2]
+
+            A0 -> parent_panel := Panel0
         end on
 
         function make_settings(fam)
@@ -1935,6 +1940,8 @@ class ControlParTest(unittest.TestCase):
         self.assertTrue('message(get_control_par(get_ui_id($myfam__myknob),$CONTROL_PAR_POS_X))' in output)
         self.assertTrue('message(get_control_par_str(get_ui_id($myfam__myknob),$CONTROL_PAR_TEXT))' in output)
         self.assertTrue('set_control_par(get_ui_id($Engine__label),$CONTROL_PAR_PARENT_PANEL,get_ui_id($Engine__panel))' in output)
+        self.assertTrue('set_control_par(get_ui_id($A0),$CONTROL_PAR_PARENT_PANEL,get_ui_id($Panel0))' in output)
+
         # ... but not on this one (since it uses an integer variable and not a UI variable):
         self.assertTrue('set_control_par($control_reference,$CONTROL_PAR_VALUE,10)' in output)
         self.assertTrue('set_control_par(get_ui_id($Engine__label),$CONTROL_PAR_PICTURE_STATE,$Engine__knob)' in output)


### PR DESCRIPTION
Updates the relevant test too