### PR TITLE
Removed warning for duplicate callbacks within ASTModifierCombineCallbacks

### DIFF
--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -640,9 +640,7 @@ class ASTModifierCombineCallbacks(ASTModifierBase):
                 cb_key = b.name + ui_name
 
                 if cb_key in callbacks:
-                    if not self.combine_callbacks:
-                        raise ksp_ast.ParseException(b, "This callback has already been declared! Either remove the duplicate, or enable the Combine Duplicate Callbacks option.")
-                    else:
+                    if  self.combine_callbacks:
                         children = b.get_childnodes()
 
                         if b.variable:

--- a/compiler/tests.py
+++ b/compiler/tests.py
@@ -107,16 +107,6 @@ end on'''
         expected_output = [l.strip() for l in expected_output.split('\n') if l]
         self.assertEqual(output, expected_output)
 
-    def testCombineCallbacksError(self):
-        code = '''
-        on init
-            declare x := 1
-        end on
-        on init
-            declare y := 1
-        end on'''
-        self.assertRaises(ParseException, do_compile, code, combine_callbacks=False)
-
     def testCombineUICallbacks(self):
         code = '''
         on init


### PR DESCRIPTION
As this occurs before the code optimization a warning is raised prematurely, this stopped scripts from compiling. This check is done later by extra_syntax_checks.