### PR TITLE
Overloaded macros

### DIFF
--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -825,7 +825,6 @@ class ASTModifierFixReferencesAndFamilies(ASTModifierBase):
             else:
                 raise ksp_ast.ParseException(node, 'Function already declared!')
         else:
-            # print(node.name.params)
             functions[node.name.identifier] = node
 
         # modify the body of the function

--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -157,6 +157,11 @@ class StringIO:
     def getvalue(self):
         return ''.join(self.parts)
 
+def append_overloaded_name(name, params):
+    '''Returns name with number of arguments appended'''
+    name = name + "__" + str(len(params))
+    return name
+
 def prefix_with_ns(name, namespaces, function_parameter_names=None, force_prefixing=False):
     '''Returns prefixed name'''
 
@@ -283,6 +288,9 @@ class Macro:
 
     def get_name_prefixed_by_namespace(self):
         return prefix_with_ns(self.name, self.lines[0].namespaces)
+
+    def get_overloaded_name(self):
+        return append_overloaded_name(self.name, self.parameters)
 
     def get_macro_name_and_parameters(self):
         '''Returns the function name, parameter list, and result variable (or None) as a tuple'''
@@ -507,6 +515,8 @@ def extract_macros(lines_deque):
         # else if line outside of macro definition
         else:
             cleaned_lines.append(line)
+
+    print(macros)
     return (cleaned_lines, macros)
 
 def extract_callback_lines(lines):
@@ -538,6 +548,8 @@ def expand_macros(lines, macros, level=0, replace_raw=True):
 
     for m in macros:
         name = m.get_name_prefixed_by_namespace()
+        name = m.get_overloaded_name()
+        print(name)
         if not (name == 'tcm.init' and name in name2macro):
             name2macro[name] = m
 
@@ -810,6 +822,7 @@ class ASTModifierFixReferencesAndFamilies(ASTModifierBase):
             else:
                 raise ksp_ast.ParseException(node, 'Function already declared!')
         else:
+            # print(node.name.params)
             functions[node.name.identifier] = node
 
         # modify the body of the function

--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -159,6 +159,7 @@ class StringIO:
 
 def append_overloaded_name(name, params):
     '''Returns name with number of arguments appended'''
+    print(params)
     name = name + "__" + str(len(params))
     return name
 
@@ -516,7 +517,6 @@ def extract_macros(lines_deque):
         else:
             cleaned_lines.append(line)
 
-    print(macros)
     return (cleaned_lines, macros)
 
 def extract_callback_lines(lines):
@@ -549,7 +549,6 @@ def expand_macros(lines, macros, level=0, replace_raw=True):
     for m in macros:
         name = m.get_name_prefixed_by_namespace()
         name = m.get_overloaded_name()
-        print(name)
         if not (name == 'tcm.init' and name in name2macro):
             name2macro[name] = m
 
@@ -565,6 +564,10 @@ def expand_macros(lines, macros, level=0, replace_raw=True):
         if m:
             macro_name, args = m.group(1), m.group(2)
             macro_name = prefix_with_ns(macro_name, line.namespaces)
+            if args:
+                macro_name = append_overloaded_name(macro_name, utils.split_args(args[1:-1], line))
+            else:
+                macro_name = append_overloaded_name(macro_name, [])
 
             if macro_name in name2macro:
                 new_lines.pop()

--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -547,7 +547,7 @@ def expand_macros(lines, macros, level=0, replace_raw=True):
     name2macro = {}
 
     for m in macros:
-        name = m.get_name_prefixed_by_namespace()
+        m.name = m.get_name_prefixed_by_namespace()
         name = m.get_overloaded_name()
         if not (name == 'tcm.init' and name in name2macro):
             name2macro[name] = m

--- a/compiler/tests.py
+++ b/compiler/tests.py
@@ -940,6 +940,44 @@ class MacroDefineChecks(unittest.TestCase):
         output = do_compile(code)
         self.assertTrue('message("MYDEFINE")' in output)
 
+class MacroOverloading(unittest.TestCase):
+    def testOverloadedWithNumArgs(self):
+        code = '''
+        on init
+            test_macro()
+            test_macro(a)
+            test_macro(a,b,c)
+        end on
+        macro test_macro
+            message("macro with 0 arguments")
+        end macro
+        macro test_macro(#name#)
+            message("macro with 1 argument")
+        end macro
+        macro test_macro(#name#, #x#, #y#)
+            message("macro with 3 arguments")
+        end macro
+        '''
+        output = do_compile(code)
+        self.assertTrue('message("macro with 0 arguments")' in output)
+        self.assertTrue('message("macro with 1 argument")' in output)
+        self.assertTrue('message("macro with 3 arguments")' in output)
+    def testOverloadedNestedWithNumArgs(self):
+        code = '''
+        on init
+            test_macro()
+        end on
+        macro test_macro
+            message("macro with 0 arguments")
+            test_macro(a,b,c)
+        end macro
+        macro test_macro(#name#, #x#, #y#)
+            message("macro with 3 arguments")
+        end macro'''
+        output = do_compile(code)
+        self.assertTrue('message("macro with 0 arguments")' in output)
+        self.assertTrue('message("macro with 3 arguments")' in output)
+
 class MacroInlining(unittest.TestCase):
     def testBasicMacroInlining(self):
         code = '''

--- a/compiler/tests.py
+++ b/compiler/tests.py
@@ -1463,22 +1463,44 @@ class NamespacePrefixing(unittest.TestCase):
         output = do_compile(code, optimize=True, read_file_func=default_read_file_func)
         self.assertTrue('x := 8' in output)
 
-    # def testMacroBodyNotPrefixed(self):
-    #     def default_read_file_func(filepath):
-    #         assert(filepath == 'mymodule.txt')
-    #         return '''
-    #             macro declare_var(var)
-    #               declare var
-    #             end macro
-    #             '''
-    #     code = '''
-    #         import 'mymodule.txt' as mymodule
+    def testMacroImportedPrefixed(self):
+        def default_read_file_func(filepath):
+            assert(filepath == 'mymodule.txt')
+            return '''
+                macro declare_var(var)
+                  declare var
+                end macro
+                '''
+        code = '''
+            import 'mymodule.txt' as mymodule
 
-    #         on init
-    #             mymodule.declare_var(x)
-    #         end on'''
-    #     output = do_compile(code, read_file_func=default_read_file_func)
-    #     self.assertTrue('declare $x' in output)
+            on init
+                mymodule.declare_var(variable)
+            end on'''
+        output = do_compile(code, read_file_func=default_read_file_func)
+        self.assertTrue('declare $mymodule__variable' in output)
+
+    def testOverloadedMacroImportedPrefixed(self):
+        def default_read_file_func(filepath):
+            assert(filepath == 'mymodule.txt')
+            return '''
+                macro foo
+                  message("macro with no arguments")
+                end macro
+                macro foo(a,b)
+                  message("macro with 2 arguments")
+                end macro
+                '''
+        code = '''
+            import 'mymodule.txt' as mymodule
+
+            on init
+                mymodule.foo
+                mymodule.foo(0,0)
+            end on'''
+        output = do_compile(code, read_file_func=default_read_file_func)
+        self.assertTrue('message("macro with no arguments")' in output)
+        self.assertTrue('message("macro with 2 arguments")' in output)
 
 class PragmaTests(unittest.TestCase):
     def testPragma(self):


### PR DESCRIPTION
Allows for different macros to be called depending on the number of arguments. When macros are being expanded they are temporarily renamed with "__[num-args]".

Will cause an 'duplicate macro' error if the new name matches a pre-existing macro.

For example:
```
on init
	test_macro()
	test_macro(a,b,c)
end on
macro test_macro
	message("macro with 0 arguments")
end macro
macro test_macro(#name#, #x#, #y#)
	message("macro with 3 arguments")
end macro
```
\\/ Goes to...
```
on init
	test_macro__0()
	test_macro__3(a,b,c)
end on
macro test_macro__0
	message("macro with 0 arguments")
end macro
macro test_macro__3(#name#, #x#, #y#)
	message("macro with 3 arguments")
end macro
```
\\/ Expands to...
```
on init
  message("macro with 0 arguments")
  message("macro with 3 arguments")
end on
```