### PR TITLE
Add option that enables completions for vanilla KSP built-ins (requires ST restart)

### DIFF
--- a/KScript Dark.sublime-color-scheme
+++ b/KScript Dark.sublime-color-scheme
@@ -1,0 +1,109 @@
+{
+    "name": "SublimeKSP Dark Theme",
+    "author": "EvilDragon",
+    "globals":
+    {
+        "foreground": "#999",
+        "background": "#191919",
+        "caret": "#999",
+        "invisibles": "#444",
+        "line_highlight": "#222",
+        "selection": "#333",
+        "gutter_foreground": "#999",
+        "brackets_options": "foreground underline bold",
+        "brackets_foreground": "#F00",
+        "bracket_contents_options": "foreground bold",
+        "bracket_contents_foreground": "#F00"
+    },
+    "rules":
+    [
+        {
+            "name": "Keyword",
+            "scope": "keyword",
+            "foreground": "#069",
+            "font_style": "bold"
+        },
+        {
+            "name": "Operator",
+            "scope": "operator",
+            "foreground": "#888"
+        },
+        {
+            "name": "Arithmetic Operator",
+            "scope": "arithmetic",
+            "foreground": "#888"
+        },
+        {
+            "name": "Identifier",
+            "scope": "variable",
+            "foreground": "#963996"
+        },
+        {
+            "name": "Family name",
+            "scope": "entity.name.type",
+            "foreground": "#939",
+            "font_style": "italic"
+        },
+        {
+            "name": "Function parameter",
+            "scope": "variable.parameter",
+            "foreground": "#C96"
+        },
+        {
+            "name": "Function argument",
+            "scope": "meta.function-call.arguments",
+            "foreground": "#939"
+        },
+        {
+            "name": "Built-in variable or constant",
+            "scope": "support.variable",
+            "foreground": "#C9C"
+        },
+        {
+            "name": "User function definition",
+            "scope": "entity.name.function",
+            "foreground": "#F60",
+            "font_style": "bold"
+        },
+        {
+            "name": "User function call",
+            "scope": "meta.function-call -function.ksp",
+            "foreground": "#F60"
+        },
+        {
+            "name": "Built-in function call",
+            "scope": "support.function",
+            "foreground": "#A70"
+        },
+        {
+            "name": "Number",
+            "scope": "constant.numeric",
+            "foreground": "#09C"
+        },
+        {
+            "name": "String single quoted",
+            "scope": "string.quoted.single",
+            "foreground": "#966"
+        },
+        {
+            "name": "String double quoted",
+            "scope": "string.quoted.double",
+            "foreground": "#966"
+        },
+        {
+            "name": "Comment",
+            "scope": "comment",
+            "foreground": "#074"
+        },
+        {
+            "name": "Punctuation",
+            "scope": "punctuation",
+            "foreground": "#888"
+        },
+        {
+            "name": "Parentheses",
+            "scope": "parentheses -begin.source.ksp -end.source.ksp",
+            "foreground": "#888"
+        }
+    ]
+}

--- a/KScript Light.sublime-color-scheme
+++ b/KScript Light.sublime-color-scheme
@@ -1,0 +1,101 @@
+{
+    "name": "SublimeKSP Light Theme",
+    "author": "EvilDragon",
+    "globals":
+    {
+        "foreground": "#000",
+        "background": "#fff",
+        "caret": "#000",
+        "invisibles": "#aaa",
+        "line_highlight": "#f0f0f0",
+        "selection": "#ddd",
+        "gutter_foreground": "#999",
+        "brackets_options": "foreground underline",
+        "brackets_foreground": "#5555FF",
+        "bracket_contents_options": "foreground",
+        "bracket_contents_foreground": "#33B"
+    },
+    "rules":
+    [
+        {
+            "name": "Keyword",
+            "scope": "keyword",
+            "foreground": "#00007F",
+            "font_style": "bold"
+        },
+        {
+            "name": "Operator",
+            "scope": "operator",
+            "foreground": "#000000"
+        },
+        {
+            "name": "Arithmetic Operator",
+            "scope": "arithmetic",
+            "foreground": "#000000"
+        },
+        {
+            "name": "Identifier",
+            "scope": "variable",
+            "foreground": "#882288"
+        },
+        {
+            "name": "Family name",
+            "scope": "entity.name.type",
+            "foreground": "#000",
+            "font_style": "italic"
+        },
+        {
+            "name": "Function parameter",
+            "scope": "variable.parameter",
+            "foreground": "#882288"
+        },
+        {
+            "name": "Function argument",
+            "scope": "meta.function-call.arguments",
+            "foreground": "#882288"
+        },
+        {
+            "name": "Built-in variable or constant",
+            "scope": "support.variable",
+            "foreground": "#785505"
+        },
+        {
+            "name": "User function definition",
+            "scope": "entity.name.function",
+            "foreground": "#DD6000",
+            "font_style": "bold"
+        },
+        {
+            "name": "User function call",
+            "scope": "meta.function-call -function.ksp",
+            "foreground": "#DD6000"
+        },
+        {
+            "name": "Built-in function call",
+            "scope": "support.function",
+            "foreground": "#c00"
+        },
+        {
+            "name": "Number",
+            "scope": "constant.numeric",
+            "foreground": "#222288"
+        },
+        {
+            "name": "String single quoted",
+            "scope": "string.quoted.single",
+            "foreground": "#990",
+            "font_style": "italic"
+        },
+        {
+            "name": "String double quoted",
+            "scope": "string.quoted.double",
+            "foreground": "#990",
+            "font_style": "italic"
+        },
+        {
+            "name": "Comment",
+            "scope": "comment",
+            "foreground": "#007F00"
+        }
+    ]
+}

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -128,6 +128,17 @@
 					{"caption":"-"}, //separator
 
 					{
+						"command": "ksp_global_setting_toggle",
+						"args": {"setting": "ksp_add_completions_for_vanilla_builtins", "default": false},
+						"caption": "Enable Completions for Vanilla KSP Built-ins (Reopen Sublime Text!)",
+						"mnemonic": "V",
+						"id": "add_completions_for_vanilla_builtins",
+						"checkbox": true
+					},
+
+					{"caption":"-"}, //separator
+
+					{
 						"command": "ksp_about",
 						"caption": "About SublimeKSP...",
 						"mnemonic": "A",

--- a/Monokai KSP.sublime-color-scheme
+++ b/Monokai KSP.sublime-color-scheme
@@ -1,0 +1,106 @@
+{
+    "name": "SublimeKSP Monokai Theme",
+    "author": "EvilDragon",
+    "globals":
+    {
+        "foreground": "#E3E3E3",
+        "background": "#272822",
+        "caret": "#F8F8F0",
+        "invisibles": "#3B3A32",
+        "line_highlight": "#3E3D32",
+        "selection": "#49483E",
+        "gutter_foreground": "#5C5B4C",
+        "brackets_options": "foreground underline bold",
+        "brackets_foreground": "#F00",
+        "bracket_contents_options": "foreground bold",
+        "bracket_contents_foreground": "#F00"
+    },
+    "rules":
+    [
+        {
+            "name": "Keyword",
+            "scope": "keyword",
+            "foreground": "#FF4C4C"
+        },
+        {
+            "name": "Operator",
+            "scope": "operator",
+            "foreground": "#587ED1"
+        },
+        {
+            "name": "Arithmetic Operator",
+            "scope": "arithmetic",
+            "foreground": "#A3A0A0"
+        },
+        {
+            "name": "Identifier",
+            "scope": "variable",
+            "foreground": "#E3E3E3"
+        },
+        {
+            "name": "Family name",
+            "scope": "entity.name.type",
+            "foreground": "#7ED694",
+            "font_style": "italic"
+        },
+        {
+            "name": "Function parameter",
+            "scope": "variable.parameter",
+            "foreground": "#FCA841",
+            "font_style": "italic"
+        },
+        {
+            "name": "Function argument",
+            "scope": "meta.function-call.arguments",
+            "foreground": "#FFA538",
+            "font_style": "italic"
+        },
+        {
+            "name": "Built-in variable or constant",
+            "scope": "support.variable",
+            "foreground": "#90D8E0"
+        },
+        {
+            "name": "User function definition",
+            "scope": "entity.name.function",
+            "foreground": "#95C43F",
+            "font_style": "bold"
+        },
+        {
+            "name": "User function call",
+            "scope": "meta.function-call -function.ksp",
+            "foreground": "#95A6BA"
+        },
+        {
+            "name": "Built-in function call",
+            "scope": "support.function",
+            "foreground": "#84DAEB"
+        },
+        {
+            "name": "Number",
+            "scope": "constant.numeric",
+            "foreground": "#B891FA"
+        },
+        {
+            "name": "String single quoted",
+            "scope": "string.quoted.single",
+            "foreground": "#FFDF5E"
+        },
+        {
+            "name": "String double quoted",
+            "scope": "string.quoted.double",
+            "foreground": "#FFDF5E"
+        },
+        {
+            "name": "Comment",
+            "scope": "comment",
+            "foreground": "#75715E",
+            "font_style": "italic"
+        },
+        {
+            "name": "Parentheses",
+            "scope": "parentheses -begin.source.ksp -end.source.ksp",
+            "foreground": "#E3E3E3"
+        }
+    ]
+}

--- a/compiler/utils.py
+++ b/compiler/utils.py
@@ -14,6 +14,9 @@
 
 import sys
 from time import strftime, localtime
+from platform import system
+import os.path
+import ctypes
 
 try:
     from sublime import status_message
@@ -85,3 +88,13 @@ def calc_time_diff(timedelta):
 
     return fmt
 
+def is_symlink(path):
+    '''Replacement for os.path.islink() so that it properly recognizes directory junctions on Windows'''
+    if os.path.isdir(path):
+        if system() == 'Windows':
+            REPARSE_POINT_TAG = 0x0400
+            return (ctypes.windll.kernel32.GetFileAttributesW(str(path)) & REPARSE_POINT_TAG) or os.path.islink(path)
+        else:
+            return os.path.islink(path)
+    else:
+        return os.path.islink(path)

--- a/messages/1.17.2.txt
+++ b/messages/1.17.2.txt
@@ -5,7 +5,7 @@ This is a minor update with the following changes:
 
 - Fixes an issue introduced in 1.17.1, where import paths wouldn't be checked if they exist before compilation continued. Now works again!
 
-- Option "Play sound when compilation finishes" now finally works even for SublimeKSP installations done viaPackage Control!
+- Option "Play sound when compilation finishes" now finally works even for SublimeKSP installations done via Package Control!
 
 
 Have fun!


### PR DESCRIPTION
Add .sublime-color-scheme based sKSP color themes
Add is_symlink to utils.py (correctly recognizes folder junctions on Windows as symlinks)
Fix typo in 1.17.2 message