### PR TITLE
Fix or/xor/.or./.xor. operator precedence

### DIFF
--- a/compiler/ksp_ast.py
+++ b/compiler/ksp_ast.py
@@ -20,16 +20,17 @@ from ksp_builtins import functions_with_forced_parentheses
 
 precedence = {  '&' :  0,
                 'or':  1,
-                'and': 2,
-                'not': 3,
-                '=': 4, '<': 4, '>': 4, '<=': 4, '>=': 4, '#': 4,
-                '.xor.': 5,
+                'xor': 2,
+                'and': 3,
+                'not': 4,
+                '=': 5, '<': 5, '>': 5, '<=': 5, '>=': 5, '#': 5,
                 '.or.': 6,
-                '.and.': 7,
-                '.not.': 8,
-                '+': 9, '-': 9,
-                '*': 10, '/': 10, 'mod': 10,
-                'unary-': 11,
+                '.xor.': 7,
+                '.and.': 8,
+                '.not.': 9,
+                '+': 10, '-': 10,
+                '*': 11, '/': 11, 'mod': 11,
+                'unary-': 12,
                 }
 
 def toint(i, bits=32):

--- a/compiler/ksp_compiler_extras.py
+++ b/compiler/ksp_compiler_extras.py
@@ -134,7 +134,7 @@ def evaluate_expression(expr):
                 return a & b
             elif op == '.or.':
                 return a | b
-            elif op == '.xor.':
+            else:
                 return a ^ b
         elif op == 'mod':
             # we don't have to check if b is int type, since we already check for type mismatches in visitBinOp function
@@ -150,13 +150,15 @@ def evaluate_expression(expr):
                 return Decimal(math.fmod(a, b))
         elif op == '&':
             return str(a) + str(b)
-        elif op in ['and', 'or']:
+        elif op in ['and', 'xor', 'or']:
             a, b = bool(a), bool(b)
 
             if op == 'and':
                 return a and b
-            else:
+            elif op == 'or':
                 return a or b
+            else:
+                return a ^ b
     elif isinstance(expr, UnaryOp):
         a = evaluate_expression(expr.right)
 


### PR DESCRIPTION
Based on [report from Nils Liberg](https://vi-control.net/community/threads/sublimeksp-updates-current-version-1-17-2.89181/page-6#post-5448940).