### PR TITLE
Introduce prepending and appending to a literal define list (+=, =+)

### DIFF
--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -687,7 +687,7 @@ contexts:
       comment: Identifier
       scope: variable.source.ksp
 
-    - match: ':=|&|<=|>=|<|>|#|=|->|\.\.\.'
+    - match: '[:+]=|[=][+]|&|<=|>=|<|>|#|=|->|\.\.\.'
       comment: Operator
       scope: operator.source.ksp
 


### PR DESCRIPTION
Enables fun stuff like:

```
define FOO := name
define FOO += surname
define FOO =+ how, about, them, apples

on init
    literate_macro(declare #l#) on HELLO
    literate_macro(message(#l#)) on HELLO
end on
```

which results in:

```
on init
    declare $how
    declare $about
    declare $them
    declare $apples
    declare $name
    declare $surname
    message($how)
    message($about)
    message($them)
    message($apples)
    message($name)
    message($surname)
end on
```

Wahey!