### PR TITLE
Additional branch optimization totally corrupts compiles that include TCM

### DIFF
--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -2314,7 +2314,6 @@ class KSPCompiler(object):
 
                  ('parsing code',                     lambda: self.parse_code(),                                                         True,                   1),
                  ('combining callbacks',              lambda: ASTModifierCombineCallbacks(self.module, self.combine_callbacks),          True,                   1),
-                 ('removing unused branches',         lambda: comp_extras.ASTModifierRemoveUnusedBranches(self.module),                  do_abo,                 1),
                  ('modifying nodes to native KSP',    lambda: ASTModifierNodesToNativeKSP(self.module, self.lines),                      True,                   1),
                  ('adding variable name prefixes',    lambda: ASTModifierFixPrefixesIncludingLocalVars(self.module),                     True,                   1),
                  ('inlining functions',               lambda: ASTModifierFunctionExpander(self.module),                                  True,                   1),


### PR DESCRIPTION
I've investigated a fix but the AST visitors in this codebase seem to return inconsistent data types depending on the stage of compiler, so there are layers and layers of complexity to tracing the code transformations and from what I was seeing they're big systemic design issues and can't be fixed with some one-liners or typecasts.

Closes #436.