### PR TITLE
Fix erroneous empty line in .sublime-syntax file

### DIFF
--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -251,7 +251,6 @@ contexts:
       scope: string.quoted.single.source.ksp
 
     - match: '(?x)
-
       (\$)?
       \b(
         ALL_(EVENTS|GROUPS)|


### PR DESCRIPTION
Improve automatic syntax detection (better query for declare, define and message statements, and score has to be more than 2)
When loading the plugin read the syntax-specific color scheme and if it's one of our own, replace .tmTheme with .sublime-color-schmee version