### PR TITLE
Allow # as character in variable name of UICB declarations

### DIFF
--- a/KSP.sublime-syntax
+++ b/KSP.sublime-syntax
@@ -50,7 +50,7 @@ contexts:
       comment: Operator
       scope: keyword.operator.source.ksp
 
-    - match: '(on\s+ui_control(s)?)(\s*\(([a-zA-Z0-9$%@?_.]+)\))?'
+    - match: '(on\s+ui_control(s)?)(\s*\(([$%@?]?[a-zA-Z0-9_#.]+)\))?'
       comment: UI callback
       captures:
         0: entity.name.callback.source.ksp


### PR DESCRIPTION
This will make the symbol list (Ctrl+R) show the full name of the variable if it contains macro #tokens#