### PR TITLE
Add indent size compiler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,17 @@ positional arguments:
   output_file
 
 optional arguments:
-  -h, --help                   show this help message and exit
-  -f, --force                  force all specified compiler options, overriding any compile_with pragma directives from the script
-  -c, --compact                remove indents and empty lines in compiled code
-  -v, --compact_variables      shorten and obfuscate variable names in compiled code
-  -d, --combine_callbacks      combines duplicate callbacks - but not functions or macros
-  -e, --extra_syntax_checks    additional syntax checks during compilation
-  -o, --optimize               optimize the compiled code
-  -t, --add_compile_date       adds the date and time comment atop the compiled code
-  -x, --sanitize_exit_command  adds a dummy no-op command before every exit function call
+  -h, --help                               show this help message and exit
+  -f, --force                              force all specified compiler options, overriding any compile_with pragma directives from the script
+  -c, --compact                            remove indents and empty lines in compiled code
+  -v, --compact_variables                  shorten and obfuscate variable names in compiled code
+  -d, --combine_callbacks                  combines duplicate callbacks - but not functions or macros
+  -e, --extra_syntax_checks                additional syntax checks during compilation
+  -o, --optimize                           optimize the compiled code
+  -b, --extra_branch_optimization          adds branch optimization checks earlier in compile process, allowing define constant based branching etc.
+  -i NUM_SPACES, --indent-size NUM_SPACES  specifies how many spaces is used for indentation, if --compact compiler option is not used
+  -t, --add_compile_date                   adds the date and time comment atop the compiled code
+  -x, --sanitize_exit_command              adds a dummy no-op command before every exit function call
 
 
 > python ksp_compiler.py --force -c -e -o "<source-file-path>" "<target-file-path>"

--- a/compiler/ksp_ast.py
+++ b/compiler/ksp_ast.py
@@ -45,17 +45,18 @@ def toint(i, bits=32):
 class Emitter:
     '''Class for converting Nodes to native KSP'''
 
-    def __init__(self, out=sys.stdout, compact=False):
+    def __init__(self, out=sys.stdout, compact=False, compiled_code_tab_size=2):
         self.out = out
         self.indent_num = 0
         self.beginning_of_line = True
         self.compact = compact
+        self.compiled_code_tab_size = compiled_code_tab_size
 
     def indent(self):
-        self.indent_num += 2
+        self.indent_num += self.compiled_code_tab_size
 
     def dedent(self):
-        self.indent_num -= 2
+        self.indent_num -= self.compiled_code_tab_size
 
     def _write_string(self, s):
         lines = s.split('\n')

--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -2049,15 +2049,16 @@ class KSPCompiler(object):
     def __init__(self,
                  source,
                  basedir,
-                 compact = True,
-                 compact_variables = False,
-                 combine_callbacks = False,
-                 extra_syntax_checks = False,
-                 optimize = False,
+                 compact                        = True,
+                 compact_variables              = False,
+                 combine_callbacks              = False,
+                 extra_syntax_checks            = False,
+                 optimize                       = False,
                  additional_branch_optimization = False,
-                 sanitize_exit_command = False,
-                 add_compiled_date_comment = False,
-                 force_compiler_arguments = False):
+                 sanitize_exit_command          = False,
+                 add_compiled_date_comment      = False,
+                 force_compiler_arguments       = False,
+                 compiled_code_tab_size         = 2):
 
         self.source = source
         self.basedir = basedir
@@ -2069,6 +2070,7 @@ class KSPCompiler(object):
         self.combine_callbacks = combine_callbacks
         self.add_compiled_date_comment = add_compiled_date_comment
         self.force_compiler_arguments = force_compiler_arguments
+        self.compiled_code_tab_size = compiled_code_tab_size
         self.extra_syntax_checks = extra_syntax_checks or optimize
 
         self.abort_requested = False
@@ -2305,7 +2307,7 @@ class KSPCompiler(object):
         '''Generate compiled code from AST'''
 
         buffer = StringIO()
-        emitter = ksp_ast.Emitter(buffer, compact = self.compact)
+        emitter = ksp_ast.Emitter(buffer, compact = self.compact, compiled_code_tab_size = self.compiled_code_tab_size)
         self.module.emit(emitter)
         self.compiled_code = buffer.getvalue()
 
@@ -2524,6 +2526,9 @@ if __name__ == "__main__":
     arg_parser.add_argument('-b', '--extra_branch_optimization',
                             dest = 'additional_branch_optimization', action = 'store_true', default = False,
                             help = 'adds branch optimization checks earlier in compile process, allowing define constant based branching etc.')
+    arg_parser.add_argument('-i', '--indent-size',
+                            dest = 'num_spaces', action = 'store', type = int, default = 2,
+                            help = 'specifies how many spaces is used for indentation, if --compact compiler option is not used')
     arg_parser.add_argument('-t', '--add_compile_date',
                             dest = 'add_compile_date', action = 'store_true', default = False,
                             help = 'adds the date and time comment atop the compiled code')
@@ -2552,15 +2557,16 @@ if __name__ == "__main__":
 
     compiler = KSPCompiler(code,
                            basepath,
-                           compact = args.compact,
-                           combine_callbacks = args.combine_callbacks,
-                           compact_variables = args.compact_variables,
-                           extra_syntax_checks = args.extra_syntax_checks,
-                           optimize = args.optimize,
+                           compact                        = args.compact,
+                           combine_callbacks              = args.combine_callbacks,
+                           compact_variables              = args.compact_variables,
+                           extra_syntax_checks            = args.extra_syntax_checks,
+                           optimize                       = args.optimize,
                            additional_branch_optimization = args.additional_branch_optimization,
-                           sanitize_exit_command = args.sanitize_exit_command,
-                           add_compiled_date_comment = (args.add_compile_date),
-                           force_compiler_arguments = (args.force_compiler_arguments))
+                           sanitize_exit_command          = args.sanitize_exit_command,
+                           add_compiled_date_comment      = args.add_compile_date,
+                           force_compiler_arguments       = args.force_compiler_arguments,
+                           compiled_code_tab_size         = args.num_spaces)
 
     compiler.compile(callback = utils.compile_on_progress)
 

--- a/ksp_plugin.py
+++ b/ksp_plugin.py
@@ -195,6 +195,7 @@ class CompileKspThread(threading.Thread):
             additional_branch_optimization = settings.get('ksp_additional_branch_optimization', False)
             add_compiled_date_comment = settings.get('ksp_add_compiled_date', True)
             should_play_sound = settings.get('ksp_play_sound', False)
+            compiled_code_tab_size = settings.get('ksp_compiled_code_tab_size', 2)
 
             error_msg = None
             error_lineno = None
@@ -230,7 +231,8 @@ class CompileKspThread(threading.Thread):
                                                          optimize                       = check and optimize,
                                                          additional_branch_optimization = check and additional_branch_optimization,
                                                          sanitize_exit_command          = sanitize_exit_command,
-                                                         add_compiled_date_comment      = add_compiled_date_comment)
+                                                         add_compiled_date_comment      = add_compiled_date_comment,
+                                                         compiled_code_tab_size         = compiled_code_tab_size)
 
                 if self.compiler.compile(callback = utils.compile_on_progress):
                     last_compiler = self.compiler


### PR DESCRIPTION
ksp_compiled_code_tab_size for Sublime Text settings
-i NUM_SPACES or --indent-size NUM_SPACES (NUM_SPACES being integer) for CLI
Update README