### PR TITLE
Compiler now detects VarRefs used as lvalues

### DIFF
--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -1423,7 +1423,6 @@ class ASTModifierNameFixer(ASTModifierBase):
 
         return node
 
-
 class ASTModifierFunctionExpander(ASTModifierBase):
     '''Handle function usage'''
     def __init__(self, ast):
@@ -2302,6 +2301,7 @@ class KSPCompiler(object):
     def init_extra_syntax_checks(self):
         comp_extras.clear_symbol_table()
         self.used_variables = set()
+        self.var_assigns = {}
 
     def generate_compiled_code(self):
         '''Generate compiled code from AST'''
@@ -2335,6 +2335,7 @@ class KSPCompiler(object):
         try:
             used_functions = set()
             used_variables = set()
+            var_assigns = {}
 
             time_so_far = 0
 
@@ -2416,8 +2417,8 @@ class KSPCompiler(object):
                  ('removing unused branches',         lambda: comp_extras.ASTModifierRemoveUnusedBranches(self.module),                  do_optim,               1),
                  ('finding unused functions',         lambda: comp_extras.ASTVisitorFindUsedFunctions(self.module, used_functions),      do_optim,               1),
                  ('removing unused functions',        lambda: comp_extras.ASTModifierRemoveUnusedFunctions(self.module, used_functions), do_optim,               1),
-                 ('finding unused variables',         lambda: comp_extras.ASTVisitorFindUsedVariables(self.module, used_variables),      do_optim,               1),
-                 ('removing unused variables',        lambda: comp_extras.ASTModifierRemoveUnusedVariables(self.module, used_variables), do_optim,               1),
+                 ('finding unused variables',         lambda: comp_extras.ASTVisitorFindUsedVariables(self.module, used_variables, var_assigns),      do_optim,               1),
+                 ('removing unused variables',        lambda: comp_extras.ASTModifierRemoveUnusedVariables(self.module, used_variables, var_assigns), do_optim,               1),
 
                  ('compacting variable names',        self.compact_names,                                                                self.compact_variables, 1),
                  ('generating code',                  self.generate_compiled_code,                                                       True,                   1),

--- a/compiler/tests.py
+++ b/compiler/tests.py
@@ -1512,6 +1512,22 @@ class NamespacePrefixing(unittest.TestCase):
         output = do_compile(code, optimize = True)
         self.assertTrue('_mymodule__tmp' in output)
 
+    def testFunctionReturnValuesNotPrefixedOrReadFrom(self):
+        code = '''
+            import 'test_imports/namespace2.ksp' as mymodule
+
+            on init
+                declare x
+                x := mymodule.max(8, 3)
+            end on'''
+
+        expected_output = '''
+            on init
+            end on'''
+
+        output = do_compile(code, optimize = True)
+        assert_equal(self, output, expected_output)
+
     def testFunctionReturnValuesNotPrefixed(self):
         code = '''
             import 'test_imports/namespace2.ksp' as mymodule
@@ -1519,6 +1535,7 @@ class NamespacePrefixing(unittest.TestCase):
             on init
                 declare x
                 x := mymodule.max(8, 3)
+                message(x)
             end on'''
 
         output = do_compile(code, optimize = True)
@@ -1650,6 +1667,7 @@ class OptimizationModeChecks(unittest.TestCase):
             function fn1
               declare global abc
               abc := 72
+              message(abc)
             end function
 
             function fn2
@@ -1749,6 +1767,7 @@ class PropertyTests(unittest.TestCase):
               declare _list[100]
               property list[a,b] -> _list[a*10+b]
               list[3,5] := 99
+              message(list[3,5])
             end on'''
 
         output = do_compile(code, optimize = True)
@@ -2144,6 +2163,7 @@ class TestTaskfunc(unittest.TestCase):
 
             on note
               x := randomize(44, 88)
+              message(x)
             end on'''
 
         expected_output = '''
@@ -2154,7 +2174,6 @@ class TestTaskfunc(unittest.TestCase):
             declare $fp
             $fp := 268
             declare $tx
-            declare %tstate__id[326]
             declare %tstate__fs[326]
             $tx := 0
             while ($tx<326)
@@ -2162,7 +2181,6 @@ class TestTaskfunc(unittest.TestCase):
             inc($tx)
             end while
             $tx := 0
-            %tstate__id[0] := -1
             pgs_create_key(TCM_EXCEPTION,5)
             pgs_set_key_val(TCM_EXCEPTION,$CURRENT_SCRIPT_SLOT,0)
             declare $x
@@ -2188,6 +2206,7 @@ class TestTaskfunc(unittest.TestCase):
             %p[$sp-2] := 88
             call randomize
             $x := %p[$sp-1]
+            message($x)
             end on'''
 
         output = do_compile(code, optimize = True)
@@ -2210,6 +2229,7 @@ class TestTaskfunc(unittest.TestCase):
 
             on note
               x := randomize(44, 88)
+              message(x)
             end on'''
 
         expected_output = '''
@@ -2220,7 +2240,6 @@ class TestTaskfunc(unittest.TestCase):
             declare $fp
             $fp := 268
             declare $tx
-            declare %tstate__id[326]
             declare %tstate__fs[326]
             $tx := 0
             while ($tx<326)
@@ -2228,7 +2247,6 @@ class TestTaskfunc(unittest.TestCase):
             inc($tx)
             end while
             $tx := 0
-            %tstate__id[0] := -1
             pgs_create_key(TCM_EXCEPTION,5)
             pgs_set_key_val(TCM_EXCEPTION,$CURRENT_SCRIPT_SLOT,0)
             declare $x
@@ -2254,6 +2272,7 @@ class TestTaskfunc(unittest.TestCase):
             %p[$sp-2] := 88
             call randomize
             $x := %p[$sp-1]
+            message($x)
             end on'''
 
         output = do_compile(code, optimize = True)
@@ -2274,6 +2293,7 @@ class TestTaskfunc(unittest.TestCase):
 
             on note
               randomize(44, 88, x)
+              message(x)
             end on'''
 
         expected_output = '''
@@ -2337,6 +2357,7 @@ class TestTaskfunc(unittest.TestCase):
             %p[$sp-2] := 88
             call randomize
             $x := %p[$sp-1]
+            message($x)
             end on'''
 
         output = do_compile(code, optimize = True)


### PR DESCRIPTION
...and proposes their assign statements as deletable. Only when the identifier is found elsewhere as a non lvalue (the variable being read) will the statements remain compiled.

@JackWilliams-FractureSounds Would be pretty great if you could check this commit out with your code if something breaks on your end! What the above change allows is this:

![image](https://github.com/user-attachments/assets/80c90ffc-e724-4d61-b665-497732a1d7c8)

Previously, this would inline all the string array assignments, even if you never actually referenced (read from) that string array elsewhere in the code. This can save a bunch of LOC in compiled code in case of using your own SDKs that might have a bunch of arrays with inlined data, that could be used in some products but not others, etc. etc.

Let me know!