### PR TITLE
Additional autogenerated variables and constants for const blocks

### DIFF
--- a/compiler/preprocessor_plugins.py
+++ b/compiler/preprocessor_plugins.py
@@ -782,10 +782,14 @@ class ConstBlock(object):
         ''' Return the the commands for the whole const block. '''
         newLines = collections.deque()
         newLines.append(line.copy("declare %s[%s] := (%s)" % (self.name, len(self.memberNames), ", ".join(self.memberValues))))
+        newLines.append(line.copy("declare !%s.str[%s] := (%s)" % (self.name, len(self.memberNames), ", ".join(['"{}"'.format(n.replace('__', ' ',).replace('_', ' ')) for n in self.memberNames]))))
+
         newLines.append(line.copy("declare const %s.SIZE := %s" % (self.name, len(self.memberNames))))
+        newLines.append(line.copy("declare @%s.title := \"%s\"" % (self.name, self.name.replace('__', ' ',).replace('_', ' '))))
 
         for memNum in range(len(self.memberNames)):
             newLines.append(line.copy("declare const %s.%s := %s" % (self.name, self.memberNames[memNum], self.memberValues[memNum])))
+            newLines.append(line.copy("declare const %s.%s.idx := %s" % (self.name, self.memberNames[memNum], memNum)))
 
         return(newLines)
 


### PR DESCRIPTION
This allows using the name of const block entries (string array, .str[]), the name of const block itself (string, .title)
and the index of the const block entry (.idx) directly in your code

Example:

```
on init
    const TEST
        FOO := 3
        BAR := 7
        BLAH := 5
    end const

    message(FOO.title)
    message(FOO.str[1])
    message(FOO.BLAH.idx)
end on
```

_ and __ are automatically converted to whitespace.