### PR TITLE
Disable traceback in exceptions

### DIFF
--- a/compiler/ksp_ast.py
+++ b/compiler/ksp_ast.py
@@ -15,6 +15,8 @@
 import sys, types
 import ply.lex as lex
 import copy
+import utils
+
 from decimal import Decimal
 from ksp_builtins import functions_with_forced_parentheses
 
@@ -106,6 +108,8 @@ class ParseException(SyntaxError):
     '''Parse Exceptions for parse errors after AST lex/yacc parsing'''
 
     def __init__(self, node, msg=None):
+        utils.disable_traceback()
+
         if msg is None:
             msg = 'Syntax Error'
 

--- a/compiler/ksp_ast.py
+++ b/compiler/ksp_ast.py
@@ -122,7 +122,7 @@ class ParseException(SyntaxError):
                         lineno = child.lineno
                         break
 
-            self.lineno = lineno
+            self.lineno = None if utils.DISABLE_TRACEBACK_IN_EXCEPTIONS else lineno
             self.node = node
             self.msg = msg
 

--- a/compiler/ksp_compiler.py
+++ b/compiler/ksp_compiler.py
@@ -210,9 +210,8 @@ class ExceptionWithMessage(Exception):
 class ParseException(ExceptionWithMessage):
     '''Parse Exceptions for parse errors raised before AST lex/yacc parsing'''
 
-    def __init__(self, line, message, no_traceback = False):
-        if no_traceback:
-            utils.disable_traceback()
+    def __init__(self, line, message):
+        utils.disable_traceback()
 
         if line.calling_lines:
             macro_chain = '\n'.join(['=> {}'.format(l.command.strip()) for l in line.calling_lines])

--- a/compiler/utils.py
+++ b/compiler/utils.py
@@ -18,17 +18,25 @@ from platform import system
 import os.path
 import ctypes
 
+
+DISABLE_TRACEBACK_IN_EXCEPTIONS = True
+
+
 try:
     from sublime import status_message
     has_sublime_api = True
 except ImportError:
     has_sublime_api = False
 
+
 def disable_traceback():
-    if sys.version_info < (3, 6, 2):
-        sys.tracebacklimit = None
-    else:
-        sys.tracebacklimit = 0
+    if DISABLE_TRACEBACK_IN_EXCEPTIONS:
+        __suppress_context__ = True
+
+        if sys.version_info < (3, 6, 2):
+            sys.tracebacklimit = None
+        else:
+            sys.tracebacklimit = 0
 
 def split_args(arg_string, line):
     '''converts eg. "x, y*(1+z), z" into a list ['x', 'y*(1+z)', 'z']'''


### PR DESCRIPTION
Also adds a constant in utils.py to be able to reenable traceback when debugging the compiler.

Closes #532
Closes #530 